### PR TITLE
Changed patch format

### DIFF
--- a/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/graph/DefaultScope.java
+++ b/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/graph/DefaultScope.java
@@ -148,6 +148,20 @@ public class DefaultScope implements Listener, ScopeMixin {
 		current.setNext(update);
 		return clash;
 	}
+	
+	/** 
+	 * Checks whether there are changes to create a patch.
+	 */
+	public boolean hasChanges() {
+		return !_changes.isEmpty();
+	}
+
+	/** 
+	 * Removes all recorded changes.
+	 */
+	public void dropChanges() {
+		_changes.clear();
+	}
 
 	/**
 	 * Exports recorded changes to the given {@link JsonWriter}.
@@ -163,6 +177,7 @@ public class DefaultScope implements Listener, ScopeMixin {
 	 * </p>
 	 * 
 	 * @see #applyChanges(JsonReader)
+	 * @see #hasChanges()
 	 */
 	public void createPatch(JsonWriter json) throws IOException {
 		json.beginArray();
@@ -176,7 +191,7 @@ public class DefaultScope implements Listener, ScopeMixin {
 		});
 		json.endArray();
 
-		_changes.clear();
+		dropChanges();
 	}
 
 	/**

--- a/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/graph/DefaultScope.java
+++ b/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/graph/DefaultScope.java
@@ -87,7 +87,7 @@ public class DefaultScope implements Listener, ScopeMixin {
 			return;
 		}
 		AbstractSharedGraphNode node = (AbstractSharedGraphNode) obj;
-		changes(node).put(property, SetProperty.create().setNode(node).setId(node.id()).setProperty(property));
+		changes(node).put(property, SetProperty.create().setNode(node).setId(id(node)).setProperty(property));
 	}
 
 	@Override
@@ -98,7 +98,7 @@ public class DefaultScope implements Listener, ScopeMixin {
 		AbstractSharedGraphNode node = (AbstractSharedGraphNode) obj;
 		Map<String, Command> changes = changes(node);
 		InsertElement insert = InsertElement.create();
-		insert.setElement(element).setIndex(index).setNode(node).setId(node.id()).setProperty(property);
+		insert.setElement(element).setIndex(index).setNode(node).setId(id(node)).setProperty(property);
 
 		putUpdate(changes, property, insert);
 	}
@@ -111,7 +111,7 @@ public class DefaultScope implements Listener, ScopeMixin {
 		AbstractSharedGraphNode node = (AbstractSharedGraphNode) obj;
 		Map<String, Command> changes = changes(node);
 		RemoveElement remove = RemoveElement.create();
-		remove.setIndex(index).setNode(node).setId(node.id()).setProperty(property);
+		remove.setIndex(index).setNode(node).setId(id(node)).setProperty(property);
 
 		putUpdate(changes, property, remove);
 	}


### PR DESCRIPTION
The patch currently contains 2 lists, the first contains the command configurations and the second potential additional arguments. Not all commands have additional arguments, so both list may have different length.

The new patch format is a list with one entry for each command, and each entry has the format which the command uses.