### PR TITLE
Fixed reading of fields in generated classes

### DIFF
--- a/de.haumacher.msgbuf.generator/src/main/java/de/haumacher/msgbuf/generator/MessageGenerator.java
+++ b/de.haumacher.msgbuf.generator/src/main/java/de/haumacher/msgbuf/generator/MessageGenerator.java
@@ -6,7 +6,7 @@ package de.haumacher.msgbuf.generator;
 import static de.haumacher.msgbuf.generator.CodeConvention.*;
 import static de.haumacher.msgbuf.generator.DefaultValueGenerator.*;
 import static de.haumacher.msgbuf.generator.TypeGenerator.*;
-import static de.haumacher.msgbuf.generator.util.CodeUtil.*;
+import static de.haumacher.msgbuf.generator.util.CodeUtil.stringLiteral;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -1395,13 +1395,15 @@ public class MessageGenerator extends AbstractMessageGenerator implements Defini
 		if (field.isRepeated()) {
 			line("case " + constant(field) + ": {");
 			{
+				line(mkType(field)+ " newValue = new java.util.ArrayList<>();");
 				line("in.beginArray();");
 				line("while (in.hasNext()) {");
 				{
-					line(adderName(field) + "(" + jsonReadEntry(type) + ");");
+					line("newValue.add(" + jsonReadEntry(type) + ");");
 				}
 				line("}");
 				line("in.endArray();");
+				line(setterName(field) + "(newValue);");
 			}
 			line("}");
 			line("break;");
@@ -1412,14 +1414,17 @@ public class MessageGenerator extends AbstractMessageGenerator implements Defini
 				Type keyType = mapType.getKeyType();
 				Type valueType = mapType.getValueType();
 				if (keyType instanceof PrimitiveType && ((PrimitiveType) keyType).getKind() == Kind.STRING) {
+					line(mkType(field)+ " newValue = new java.util.LinkedHashMap<>();");
 					line("in.beginObject();");
 					line("while (in.hasNext()) {");
 					{
-						line(adderName(field) + "(in.nextName(), " + jsonReadEntry(valueType) + ");");
+						line("newValue.put(in.nextName(), " + jsonReadEntry(valueType) + ");");
 					}
 					line("}");
 					line("in.endObject();");
+					line(setterName(field) + "(newValue);");
 				} else {
+					line(mkType(field)+ " newValue = new java.util.LinkedHashMap<>();");
 					line("in.beginArray();");
 					line("while (in.hasNext()) {");
 					{
@@ -1435,11 +1440,12 @@ public class MessageGenerator extends AbstractMessageGenerator implements Defini
 							line("}");
 						}
 						line("}");
-						line(adderName(field) + "(key, value);");
+						line("newValue.put(key, value);");
 						line("in.endObject();");
 					}
 					line("}");
 					line("in.endArray();");
+					line(setterName(field) + "(newValue);");
 				}
 			}
 			line("break;");

--- a/de.haumacher.msgbuf.generator/src/test/java/test/container/model/impl/MyContainer_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/container/model/impl/MyContainer_Impl.java
@@ -323,19 +323,23 @@ public class MyContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataObjec
 			case CONTENT_1__PROP: setContent1(test.container.model.MyContent.readMyContent(in)); break;
 			case CONTENT_2__PROP: setContent2(test.container.model.MyContent.readMyContent(in)); break;
 			case CONTENT_LIST__PROP: {
+				java.util.List<test.container.model.MyContent> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addContentList(test.container.model.MyContent.readMyContent(in));
+					newValue.add(test.container.model.MyContent.readMyContent(in));
 				}
 				in.endArray();
+				setContentList(newValue);
 			}
 			break;
 			case CONTENT_MAP__PROP: {
+				java.util.Map<String, test.container.model.MyContent> newValue = new java.util.LinkedHashMap<>();
 				in.beginObject();
 				while (in.hasNext()) {
-					putContentMap(in.nextName(), test.container.model.MyContent.readMyContent(in));
+					newValue.put(in.nextName(), test.container.model.MyContent.readMyContent(in));
 				}
 				in.endObject();
+				setContentMap(newValue);
 				break;
 			}
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/Container_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/Container_Impl.java
@@ -156,11 +156,13 @@ public class Container_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 		switch (field) {
 			case NAME__PROP: setName(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
 			case CONTENTS__PROP: {
+				java.util.List<test.embedded.data.Base> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addContent(test.embedded.data.Base.readBase(in));
+					newValue.add(test.embedded.data.Base.readBase(in));
 				}
 				in.endArray();
+				setContents(newValue);
 			}
 			break;
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/EmbeddingContainer_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/EmbeddingContainer_Impl.java
@@ -156,11 +156,13 @@ public class EmbeddingContainer_Impl extends de.haumacher.msgbuf.data.AbstractDa
 		switch (field) {
 			case NAME__PROP: setName(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
 			case CONTENTS__PROP: {
+				java.util.List<test.embedded.data.Base> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addContent(test.embedded.data.Base.readBase(in));
+					newValue.add(test.embedded.data.Base.readBase(in));
 				}
 				in.endArray();
+				setContents(newValue);
 			}
 			break;
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Group_Impl.java
@@ -137,11 +137,13 @@ public class Group_Impl extends test.graph.data.impl.Shape_Impl implements test.
 	public void readField(de.haumacher.msgbuf.graph.Scope scope, de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
 		switch (field) {
 			case SHAPES__PROP: {
+				java.util.List<test.graph.data.Shape> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addShape(test.graph.data.Shape.readShape(scope, in));
+					newValue.add(test.graph.data.Shape.readShape(scope, in));
 				}
 				in.endArray();
+				setShapes(newValue);
 			}
 			break;
 			default: super.readField(scope, in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Group_Impl.java
@@ -128,11 +128,13 @@ public class Group_Impl extends test.hierarchy.data.impl.Shape_Impl implements t
 	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
 		switch (field) {
 			case SHAPES__PROP: {
+				java.util.List<test.hierarchy.data.Shape> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addShape(test.hierarchy.data.Shape.readShape(in));
+					newValue.add(test.hierarchy.data.Shape.readShape(in));
 				}
 				in.endArray();
+				setShapes(newValue);
 			}
 			break;
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/maptype/data/impl/MyMessage_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/maptype/data/impl/MyMessage_Impl.java
@@ -198,14 +198,17 @@ public class MyMessage_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
 		switch (field) {
 			case PROJECTS__PROP: {
+				java.util.Map<String, test.maptype.data.Project> newValue = new java.util.LinkedHashMap<>();
 				in.beginObject();
 				while (in.hasNext()) {
-					putProject(in.nextName(), test.maptype.data.Project.readProject(in));
+					newValue.put(in.nextName(), test.maptype.data.Project.readProject(in));
 				}
 				in.endObject();
+				setProjects(newValue);
 				break;
 			}
 			case RATING__PROP: {
+				java.util.Map<Integer, String> newValue = new java.util.LinkedHashMap<>();
 				in.beginArray();
 				while (in.hasNext()) {
 					in.beginObject();
@@ -218,10 +221,11 @@ public class MyMessage_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 							default: in.skipValue(); break;
 						}
 					}
-					putRating(key, value);
+					newValue.put(key, value);
 					in.endObject();
 				}
 				in.endArray();
+				setRating(newValue);
 				break;
 			}
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nested/data/impl/SearchResponse_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nested/data/impl/SearchResponse_Impl.java
@@ -184,11 +184,13 @@ public class SearchResponse_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 				case URL__PROP: setUrl(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
 				case TITLE__PROP: setTitle(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
 				case SNIPPETS__PROP: {
+					java.util.List<String> newValue = new java.util.ArrayList<>();
 					in.beginArray();
 					while (in.hasNext()) {
-						addSnippet(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in));
+						newValue.add(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in));
 					}
 					in.endArray();
+					setSnippets(newValue);
 				}
 				break;
 				default: super.readField(in, field);
@@ -499,11 +501,13 @@ public class SearchResponse_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
 		switch (field) {
 			case RESULTS__PROP: {
+				java.util.List<test.nested.data.SearchResponse.Result> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addResult(test.nested.data.SearchResponse.Result.readResult(in));
+					newValue.add(test.nested.data.SearchResponse.Result.readResult(in));
 				}
 				in.endArray();
+				setResults(newValue);
 			}
 			break;
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Group.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Group.java
@@ -160,11 +160,13 @@ public class Group extends Shape {
 	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
 		switch (field) {
 			case SHAPES__PROP: {
+				java.util.List<test.nointerfaces.Shape> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addShape(test.nointerfaces.Shape.readShape(in));
+					newValue.add(test.nointerfaces.Shape.readShape(in));
 				}
 				in.endArray();
+				setShapes(newValue);
 			}
 			break;
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Group_Impl.java
@@ -112,11 +112,13 @@ public class Group_Impl extends test.nolistener.impl.Shape_Impl implements test.
 	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
 		switch (field) {
 			case SHAPES__PROP: {
+				java.util.List<test.nolistener.Shape> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addShape(test.nolistener.Shape.readShape(in));
+					newValue.add(test.nolistener.Shape.readShape(in));
 				}
 				in.endArray();
+				setShapes(newValue);
 			}
 			break;
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/noreflection/Group.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/noreflection/Group.java
@@ -114,11 +114,13 @@ public class Group extends Shape {
 	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
 		switch (field) {
 			case SHAPES__PROP: {
+				java.util.List<test.noreflection.Shape> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addShape(test.noreflection.Shape.readShape(in));
+					newValue.add(test.noreflection.Shape.readShape(in));
 				}
 				in.endArray();
+				setShapes(newValue);
 			}
 			break;
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Group_Impl.java
@@ -117,11 +117,13 @@ public class Group_Impl extends test.notypekind.impl.Shape_Impl implements test.
 	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
 		switch (field) {
 			case SHAPES__PROP: {
+				java.util.List<test.notypekind.Shape> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addShape(test.notypekind.Shape.readShape(in));
+					newValue.add(test.notypekind.Shape.readShape(in));
 				}
 				in.endArray();
+				setShapes(newValue);
 			}
 			break;
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Group_Impl.java
@@ -122,11 +122,13 @@ public class Group_Impl extends test.novisit.impl.Shape_Impl implements test.nov
 	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
 		switch (field) {
 			case SHAPES__PROP: {
+				java.util.List<test.novisit.Shape> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addShape(test.novisit.Shape.readShape(in));
+					newValue.add(test.novisit.Shape.readShape(in));
 				}
 				in.endArray();
+				setShapes(newValue);
 			}
 			break;
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Group_Impl.java
@@ -122,11 +122,13 @@ public class Group_Impl extends test.novisitexceptions.impl.Shape_Impl implement
 	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
 		switch (field) {
 			case SHAPES__PROP: {
+				java.util.List<test.novisitexceptions.Shape> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addShape(test.novisitexceptions.Shape.readShape(in));
+					newValue.add(test.novisitexceptions.Shape.readShape(in));
 				}
 				in.endArray();
+				setShapes(newValue);
 			}
 			break;
 			default: super.readField(in, field);

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nullable/data/impl/NullableValues_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nullable/data/impl/NullableValues_Impl.java
@@ -374,27 +374,33 @@ public class NullableValues_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 			case BOOLEAN__PROP: setBoolean(in.nextBoolean()); break;
 			case STRING__PROP: setString(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
 			case INT_LIST__PROP: {
+				java.util.List<Integer> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addIntList(in.nextInt());
+					newValue.add(in.nextInt());
 				}
 				in.endArray();
+				setIntList(newValue);
 			}
 			break;
 			case STRING_LIST__PROP: {
+				java.util.List<String> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addStringList(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in));
+					newValue.add(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in));
 				}
 				in.endArray();
+				setStringList(newValue);
 			}
 			break;
 			case STRING_INT_MAP__PROP: {
+				java.util.Map<String, Integer> newValue = new java.util.LinkedHashMap<>();
 				in.beginObject();
 				while (in.hasNext()) {
-					putStringIntMap(in.nextName(), in.nextInt());
+					newValue.put(in.nextName(), in.nextInt());
 				}
 				in.endObject();
+				setStringIntMap(newValue);
 				break;
 			}
 			case OPTIONAL_DECISION__PROP: setOptionalDecision(test.nullable.data.Decision.readDecision(in)); break;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/references/data/impl/A_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/references/data/impl/A_Impl.java
@@ -480,29 +480,35 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 			case NAME__PROP: setName(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
 			case CONTENTS__PROP: setContents(test.references.data.A.readA(in)); break;
 			case CHILDREN__PROP: {
+				java.util.List<test.references.data.A> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addChildren(test.references.data.A.readA(in));
+					newValue.add(test.references.data.A.readA(in));
 				}
 				in.endArray();
+				setChildren(newValue);
 			}
 			break;
 			case BS__PROP: {
+				java.util.List<test.references.data.B> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addBs(test.references.data.B.readB(in));
+					newValue.add(test.references.data.B.readB(in));
 				}
 				in.endArray();
+				setBs(newValue);
 			}
 			break;
 			case B__PROP: setB(test.references.data.B.readB(in)); break;
 			case OTHER__PROP: setOther(test.references.data.A.readA(in)); break;
 			case OTHERS__PROP: {
+				java.util.List<test.references.data.A> newValue = new java.util.ArrayList<>();
 				in.beginArray();
 				while (in.hasNext()) {
-					addOthers(test.references.data.A.readA(in));
+					newValue.add(test.references.data.A.readA(in));
 				}
 				in.endArray();
+				setOthers(newValue);
 			}
 			break;
 			default: super.readField(in, field);


### PR DESCRIPTION
The method "readField" is used by the command "set property". When the field is a repeated field, the new value is added to the existing list, which  not intended.