### PR TITLE
Added listener method "afterChanged".

### DIFF
--- a/de.haumacher.msgbuf.generator/src/main/java/de/haumacher/msgbuf/generator/MessageGenerator.java
+++ b/de.haumacher.msgbuf.generator/src/main/java/de/haumacher/msgbuf/generator/MessageGenerator.java
@@ -6,7 +6,7 @@ package de.haumacher.msgbuf.generator;
 import static de.haumacher.msgbuf.generator.CodeConvention.*;
 import static de.haumacher.msgbuf.generator.DefaultValueGenerator.*;
 import static de.haumacher.msgbuf.generator.TypeGenerator.*;
-import static de.haumacher.msgbuf.generator.util.CodeUtil.*;
+import static de.haumacher.msgbuf.generator.util.CodeUtil.stringLiteral;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -557,6 +557,15 @@ public class MessageGenerator extends AbstractMessageGenerator implements Defini
 							}
 						}
 						line("}");
+						
+						if (_listener) {
+							nl();
+							
+							line("@Override");
+							line("protected void afterChanged() {");
+								line("_listener.afterChanged(" + implName(_def) + ".this, " + constant(field) + ");");
+							line("}");
+						}
 					}
 					line("};");
 					continue;
@@ -774,6 +783,10 @@ public class MessageGenerator extends AbstractMessageGenerator implements Defini
 						}
 					}
 					line("}");
+				}
+				
+				if (_listener) {
+					line("_listener.afterChanged(this, " + constant(field) + ");");
 				}
 			}
 		}

--- a/de.haumacher.msgbuf.generator/src/test/java/test/comments/data/impl/SearchRequest_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/comments/data/impl/SearchRequest_Impl.java
@@ -35,6 +35,7 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 	protected final void internalSetQuery(String value) {
 		_listener.beforeSet(this, QUERY__PROP, value);
 		_query = value;
+		_listener.afterChanged(this, QUERY__PROP);
 	}
 
 	@Override
@@ -52,6 +53,7 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 	protected final void internalSetPageNumber(int value) {
 		_listener.beforeSet(this, PAGE_NUMBER__PROP, value);
 		_pageNumber = value;
+		_listener.afterChanged(this, PAGE_NUMBER__PROP);
 	}
 
 	@Override
@@ -69,6 +71,7 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 	protected final void internalSetResultPerPage(int value) {
 		_listener.beforeSet(this, RESULT_PER_PAGE__PROP, value);
 		_resultPerPage = value;
+		_listener.afterChanged(this, RESULT_PER_PAGE__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/container/model/impl/MyContainer_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/container/model/impl/MyContainer_Impl.java
@@ -29,6 +29,11 @@ public class MyContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataObjec
 			removed.internalSetContainer(null);
 			_listener.afterRemove(MyContainer_Impl.this, CONTENT_LIST__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(MyContainer_Impl.this, CONTENT_LIST__PROP);
+		}
 	};
 
 	private final java.util.Map<String, test.container.model.MyContent> _contentMap = new de.haumacher.msgbuf.util.ReferenceMap<String, test.container.model.MyContent>() {
@@ -49,6 +54,11 @@ public class MyContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataObjec
 			removed.internalSetContainer(null);
 			_listener.afterRemove(MyContainer_Impl.this, CONTENT_MAP__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(MyContainer_Impl.this, CONTENT_MAP__PROP);
+		}
 	};
 
 	private test.container.model.MyContent _other = null;
@@ -62,6 +72,11 @@ public class MyContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataObjec
 		@Override
 		protected void afterRemove(int index, test.container.model.MyContent element) {
 			_listener.afterRemove(MyContainer_Impl.this, OTHERS__PROP, index, element);
+		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(MyContainer_Impl.this, OTHERS__PROP);
 		}
 	};
 
@@ -89,6 +104,7 @@ public class MyContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataObjec
 	protected final void internalSetName(String value) {
 		_listener.beforeSet(this, NAME__PROP, value);
 		_name = value;
+		_listener.afterChanged(this, NAME__PROP);
 	}
 
 	@Override
@@ -120,6 +136,7 @@ public class MyContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataObjec
 		if (after != null) {
 			after.internalSetContainer(this);
 		}
+		_listener.afterChanged(this, CONTENT_1__PROP);
 	}
 
 	@Override
@@ -156,6 +173,7 @@ public class MyContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataObjec
 		if (after != null) {
 			after.internalSetContainer(this);
 		}
+		_listener.afterChanged(this, CONTENT_2__PROP);
 	}
 
 	@Override
@@ -249,6 +267,7 @@ public class MyContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataObjec
 	protected final void internalSetOther(test.container.model.MyContent value) {
 		_listener.beforeSet(this, OTHER__PROP, value);
 		_other = value;
+		_listener.afterChanged(this, OTHER__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/container/model/impl/MyContent_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/container/model/impl/MyContent_Impl.java
@@ -38,6 +38,7 @@ public class MyContent_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 			throw new IllegalStateException("Object may not be part of two different containers.");
 		}
 		_container = value;
+		_listener.afterChanged(this, CONTAINER__PROP);
 	}
 
 	@Override
@@ -60,6 +61,7 @@ public class MyContent_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 	protected final void internalSetName(String value) {
 		_listener.beforeSet(this, NAME__PROP, value);
 		_name = value;
+		_listener.afterChanged(this, NAME__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/container/nointerfaces/model/MyContainer.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/container/nointerfaces/model/MyContainer.java
@@ -78,6 +78,11 @@ public class MyContainer extends de.haumacher.msgbuf.data.AbstractDataObject imp
 			removed.internalSetContainer(null);
 			_listener.afterRemove(MyContainer.this, CONTENT_LIST__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(MyContainer.this, CONTENT_LIST__PROP);
+		}
 	};
 
 	private final java.util.Map<String, test.container.nointerfaces.model.MyContent> _contentMap = new de.haumacher.msgbuf.util.ReferenceMap<String, test.container.nointerfaces.model.MyContent>() {
@@ -98,6 +103,11 @@ public class MyContainer extends de.haumacher.msgbuf.data.AbstractDataObject imp
 			removed.internalSetContainer(null);
 			_listener.afterRemove(MyContainer.this, CONTENT_MAP__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(MyContainer.this, CONTENT_MAP__PROP);
+		}
 	};
 
 	private test.container.nointerfaces.model.MyContent _other = null;
@@ -111,6 +121,11 @@ public class MyContainer extends de.haumacher.msgbuf.data.AbstractDataObject imp
 		@Override
 		protected void afterRemove(int index, test.container.nointerfaces.model.MyContent element) {
 			_listener.afterRemove(MyContainer.this, OTHERS__PROP, index, element);
+		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(MyContainer.this, OTHERS__PROP);
 		}
 	};
 
@@ -139,6 +154,7 @@ public class MyContainer extends de.haumacher.msgbuf.data.AbstractDataObject imp
 	protected final void internalSetName(String value) {
 		_listener.beforeSet(this, NAME__PROP, value);
 		_name = value;
+		_listener.afterChanged(this, NAME__PROP);
 	}
 
 	public final test.container.nointerfaces.model.MyContent getContent1() {
@@ -171,6 +187,7 @@ public class MyContainer extends de.haumacher.msgbuf.data.AbstractDataObject imp
 		if (after != null) {
 			after.internalSetContainer(this);
 		}
+		_listener.afterChanged(this, CONTENT_1__PROP);
 	}
 
 	/**
@@ -210,6 +227,7 @@ public class MyContainer extends de.haumacher.msgbuf.data.AbstractDataObject imp
 		if (after != null) {
 			after.internalSetContainer(this);
 		}
+		_listener.afterChanged(this, CONTENT_2__PROP);
 	}
 
 	/**
@@ -316,6 +334,7 @@ public class MyContainer extends de.haumacher.msgbuf.data.AbstractDataObject imp
 	protected final void internalSetOther(test.container.nointerfaces.model.MyContent value) {
 		_listener.beforeSet(this, OTHER__PROP, value);
 		_other = value;
+		_listener.afterChanged(this, OTHER__PROP);
 	}
 
 	/**

--- a/de.haumacher.msgbuf.generator/src/test/java/test/container/nointerfaces/model/MyContent.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/container/nointerfaces/model/MyContent.java
@@ -53,6 +53,7 @@ public class MyContent extends de.haumacher.msgbuf.data.AbstractDataObject imple
 			throw new IllegalStateException("Object may not be part of two different containers.");
 		}
 		_container = value;
+		_listener.afterChanged(this, CONTAINER__PROP);
 	}
 
 	/**
@@ -78,6 +79,7 @@ public class MyContent extends de.haumacher.msgbuf.data.AbstractDataObject imple
 	protected final void internalSetName(String value) {
 		_listener.beforeSet(this, NAME__PROP, value);
 		_name = value;
+		_listener.afterChanged(this, NAME__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/defaultvalue/data/impl/A_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/defaultvalue/data/impl/A_Impl.java
@@ -37,6 +37,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetS(String value) {
 		_listener.beforeSet(this, S__PROP, value);
 		_s = value;
+		_listener.afterChanged(this, S__PROP);
 	}
 
 	@Override
@@ -54,6 +55,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetX(int value) {
 		_listener.beforeSet(this, X__PROP, value);
 		_x = value;
+		_listener.afterChanged(this, X__PROP);
 	}
 
 	@Override
@@ -71,6 +73,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetY(double value) {
 		_listener.beforeSet(this, Y__PROP, value);
 		_y = value;
+		_listener.afterChanged(this, Y__PROP);
 	}
 
 	@Override
@@ -88,6 +91,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetState(boolean value) {
 		_listener.beforeSet(this, STATE__PROP, value);
 		_state = value;
+		_listener.afterChanged(this, STATE__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/Container_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/Container_Impl.java
@@ -17,6 +17,11 @@ public class Container_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 		protected void afterRemove(int index, test.embedded.data.Base element) {
 			_listener.afterRemove(Container_Impl.this, CONTENTS__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(Container_Impl.this, CONTENTS__PROP);
+		}
 	};
 
 	/**
@@ -43,6 +48,7 @@ public class Container_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 	protected final void internalSetName(String value) {
 		_listener.beforeSet(this, NAME__PROP, value);
 		_name = value;
+		_listener.afterChanged(this, NAME__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/EmbeddingContainer_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/EmbeddingContainer_Impl.java
@@ -17,6 +17,11 @@ public class EmbeddingContainer_Impl extends de.haumacher.msgbuf.data.AbstractDa
 		protected void afterRemove(int index, test.embedded.data.Base element) {
 			_listener.afterRemove(EmbeddingContainer_Impl.this, CONTENTS__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(EmbeddingContainer_Impl.this, CONTENTS__PROP);
+		}
 	};
 
 	/**
@@ -43,6 +48,7 @@ public class EmbeddingContainer_Impl extends de.haumacher.msgbuf.data.AbstractDa
 	protected final void internalSetName(String value) {
 		_listener.beforeSet(this, NAME__PROP, value);
 		_name = value;
+		_listener.afterChanged(this, NAME__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/EmbeddingSingleContainer_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/EmbeddingSingleContainer_Impl.java
@@ -33,6 +33,7 @@ public class EmbeddingSingleContainer_Impl extends de.haumacher.msgbuf.data.Abst
 	protected final void internalSetName(String value) {
 		_listener.beforeSet(this, NAME__PROP, value);
 		_name = value;
+		_listener.afterChanged(this, NAME__PROP);
 	}
 
 	@Override
@@ -50,6 +51,7 @@ public class EmbeddingSingleContainer_Impl extends de.haumacher.msgbuf.data.Abst
 	protected final void internalSetContents(test.embedded.data.Base value) {
 		_listener.beforeSet(this, CONTENTS__PROP, value);
 		_contents = value;
+		_listener.afterChanged(this, CONTENTS__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/SingleContainer_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/SingleContainer_Impl.java
@@ -33,6 +33,7 @@ public class SingleContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataO
 	protected final void internalSetName(String value) {
 		_listener.beforeSet(this, NAME__PROP, value);
 		_name = value;
+		_listener.afterChanged(this, NAME__PROP);
 	}
 
 	@Override
@@ -50,6 +51,7 @@ public class SingleContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataO
 	protected final void internalSetContents(test.embedded.data.Base value) {
 		_listener.beforeSet(this, CONTENTS__PROP, value);
 		_contents = value;
+		_listener.afterChanged(this, CONTENTS__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/enumeration/data/impl/SearchRequest_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/enumeration/data/impl/SearchRequest_Impl.java
@@ -37,6 +37,7 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 	protected final void internalSetQuery(String value) {
 		_listener.beforeSet(this, QUERY__PROP, value);
 		_query = value;
+		_listener.afterChanged(this, QUERY__PROP);
 	}
 
 	@Override
@@ -54,6 +55,7 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 	protected final void internalSetPageNumber(int value) {
 		_listener.beforeSet(this, PAGE_NUMBER__PROP, value);
 		_pageNumber = value;
+		_listener.afterChanged(this, PAGE_NUMBER__PROP);
 	}
 
 	@Override
@@ -71,6 +73,7 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 	protected final void internalSetResultPerPage(int value) {
 		_listener.beforeSet(this, RESULT_PER_PAGE__PROP, value);
 		_resultPerPage = value;
+		_listener.afterChanged(this, RESULT_PER_PAGE__PROP);
 	}
 
 	@Override
@@ -89,6 +92,7 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 		if (value == null) throw new IllegalArgumentException("Property 'corpus' cannot be null.");
 		_listener.beforeSet(this, CORPUS__PROP, value);
 		_corpus = value;
+		_listener.afterChanged(this, CORPUS__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Car_Impl.java
@@ -40,6 +40,7 @@ public class Car_Impl extends test.graph.data.impl.Shape_Impl implements test.gr
 	protected final void internalSetWheel1(test.graph.data.Circle value) {
 		_listener.beforeSet(this, WHEEL_1__PROP, value);
 		_wheel1 = value;
+		_listener.afterChanged(this, WHEEL_1__PROP);
 	}
 
 	@Override
@@ -62,6 +63,7 @@ public class Car_Impl extends test.graph.data.impl.Shape_Impl implements test.gr
 	protected final void internalSetWheel2(test.graph.data.Circle value) {
 		_listener.beforeSet(this, WHEEL_2__PROP, value);
 		_wheel2 = value;
+		_listener.afterChanged(this, WHEEL_2__PROP);
 	}
 
 	@Override
@@ -84,6 +86,7 @@ public class Car_Impl extends test.graph.data.impl.Shape_Impl implements test.gr
 	protected final void internalSetBody(test.graph.data.Rectangle value) {
 		_listener.beforeSet(this, BODY__PROP, value);
 		_body = value;
+		_listener.afterChanged(this, BODY__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Circle_Impl.java
@@ -36,6 +36,7 @@ public class Circle_Impl extends test.graph.data.impl.AtomicShape_Impl implement
 	protected final void internalSetRadius(int value) {
 		_listener.beforeSet(this, RADIUS__PROP, value);
 		_radius = value;
+		_listener.afterChanged(this, RADIUS__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Group_Impl.java
@@ -15,6 +15,11 @@ public class Group_Impl extends test.graph.data.impl.Shape_Impl implements test.
 		protected void afterRemove(int index, test.graph.data.Shape element) {
 			_listener.afterRemove(Group_Impl.this, SHAPES__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(Group_Impl.this, SHAPES__PROP);
+		}
 	};
 
 	/**

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Rectangle_Impl.java
@@ -38,6 +38,7 @@ public class Rectangle_Impl extends test.graph.data.impl.AtomicShape_Impl implem
 	protected final void internalSetWidth(int value) {
 		_listener.beforeSet(this, WIDTH__PROP, value);
 		_width = value;
+		_listener.afterChanged(this, WIDTH__PROP);
 	}
 
 	@Override
@@ -55,6 +56,7 @@ public class Rectangle_Impl extends test.graph.data.impl.AtomicShape_Impl implem
 	protected final void internalSetHeight(int value) {
 		_listener.beforeSet(this, HEIGHT__PROP, value);
 		_height = value;
+		_listener.afterChanged(this, HEIGHT__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Shape_Impl.java
@@ -31,6 +31,7 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.graph.AbstractShare
 	protected final void internalSetXCoordinate(int value) {
 		_listener.beforeSet(this, X_COORDINATE__PROP, value);
 		_xCoordinate = value;
+		_listener.afterChanged(this, X_COORDINATE__PROP);
 	}
 
 	@Override
@@ -48,6 +49,7 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.graph.AbstractShare
 	protected final void internalSetYCoordinate(int value) {
 		_listener.beforeSet(this, Y_COORDINATE__PROP, value);
 		_yCoordinate = value;
+		_listener.afterChanged(this, Y_COORDINATE__PROP);
 	}
 
 	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/SimpleType_Impl.java
@@ -33,6 +33,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.graph.AbstractSharedGra
 	protected final void internalSetStr(String value) {
 		_listener.beforeSet(this, STR__PROP, value);
 		_str = value;
+		_listener.afterChanged(this, STR__PROP);
 	}
 
 	@Override
@@ -50,6 +51,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.graph.AbstractSharedGra
 	protected final void internalSetX(int value) {
 		_listener.beforeSet(this, X__PROP, value);
 		_x = value;
+		_listener.afterChanged(this, X__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Car_Impl.java
@@ -40,6 +40,7 @@ public class Car_Impl extends test.hierarchy.data.impl.Shape_Impl implements tes
 	protected final void internalSetWheel1(test.hierarchy.data.Circle value) {
 		_listener.beforeSet(this, WHEEL_1__PROP, value);
 		_wheel1 = value;
+		_listener.afterChanged(this, WHEEL_1__PROP);
 	}
 
 	@Override
@@ -62,6 +63,7 @@ public class Car_Impl extends test.hierarchy.data.impl.Shape_Impl implements tes
 	protected final void internalSetWheel2(test.hierarchy.data.Circle value) {
 		_listener.beforeSet(this, WHEEL_2__PROP, value);
 		_wheel2 = value;
+		_listener.afterChanged(this, WHEEL_2__PROP);
 	}
 
 	@Override
@@ -84,6 +86,7 @@ public class Car_Impl extends test.hierarchy.data.impl.Shape_Impl implements tes
 	protected final void internalSetBody(test.hierarchy.data.Rectangle value) {
 		_listener.beforeSet(this, BODY__PROP, value);
 		_body = value;
+		_listener.afterChanged(this, BODY__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Circle_Impl.java
@@ -36,6 +36,7 @@ public class Circle_Impl extends test.hierarchy.data.impl.AtomicShape_Impl imple
 	protected final void internalSetRadius(int value) {
 		_listener.beforeSet(this, RADIUS__PROP, value);
 		_radius = value;
+		_listener.afterChanged(this, RADIUS__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Group_Impl.java
@@ -15,6 +15,11 @@ public class Group_Impl extends test.hierarchy.data.impl.Shape_Impl implements t
 		protected void afterRemove(int index, test.hierarchy.data.Shape element) {
 			_listener.afterRemove(Group_Impl.this, SHAPES__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(Group_Impl.this, SHAPES__PROP);
+		}
 	};
 
 	/**

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Optional_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Optional_Impl.java
@@ -38,6 +38,7 @@ public class Optional_Impl extends test.hierarchy.data.impl.Shape_Impl implement
 	protected final void internalSetHidden(boolean value) {
 		_listener.beforeSet(this, HIDDEN__PROP, value);
 		_hidden = value;
+		_listener.afterChanged(this, HIDDEN__PROP);
 	}
 
 	@Override
@@ -55,6 +56,7 @@ public class Optional_Impl extends test.hierarchy.data.impl.Shape_Impl implement
 	protected final void internalSetShape(test.hierarchy.data.Shape value) {
 		_listener.beforeSet(this, SHAPE__PROP, value);
 		_shape = value;
+		_listener.afterChanged(this, SHAPE__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Rectangle_Impl.java
@@ -38,6 +38,7 @@ public class Rectangle_Impl extends test.hierarchy.data.impl.AtomicShape_Impl im
 	protected final void internalSetWidth(int value) {
 		_listener.beforeSet(this, WIDTH__PROP, value);
 		_width = value;
+		_listener.afterChanged(this, WIDTH__PROP);
 	}
 
 	@Override
@@ -55,6 +56,7 @@ public class Rectangle_Impl extends test.hierarchy.data.impl.AtomicShape_Impl im
 	protected final void internalSetHeight(int value) {
 		_listener.beforeSet(this, HEIGHT__PROP, value);
 		_height = value;
+		_listener.afterChanged(this, HEIGHT__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Shape_Impl.java
@@ -33,6 +33,7 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 	protected final void internalSetXCoordinate(int value) {
 		_listener.beforeSet(this, X_COORDINATE__PROP, value);
 		_xCoordinate = value;
+		_listener.afterChanged(this, X_COORDINATE__PROP);
 	}
 
 	@Override
@@ -50,6 +51,7 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 	protected final void internalSetYCoordinate(int value) {
 		_listener.beforeSet(this, Y_COORDINATE__PROP, value);
 		_yCoordinate = value;
+		_listener.afterChanged(this, Y_COORDINATE__PROP);
 	}
 
 	@Override
@@ -68,6 +70,7 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 		if (value == null) throw new IllegalArgumentException("Property 'color' cannot be null.");
 		_listener.beforeSet(this, COLOR__PROP, value);
 		_color = value;
+		_listener.afterChanged(this, COLOR__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/SimpleType_Impl.java
@@ -33,6 +33,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	protected final void internalSetStr(String value) {
 		_listener.beforeSet(this, STR__PROP, value);
 		_str = value;
+		_listener.afterChanged(this, STR__PROP);
 	}
 
 	@Override
@@ -50,6 +51,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	protected final void internalSetX(int value) {
 		_listener.beforeSet(this, X__PROP, value);
 		_x = value;
+		_listener.afterChanged(this, X__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/innertypeclash/impl/A_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/innertypeclash/impl/A_Impl.java
@@ -200,6 +200,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetAc(test.innertypeclash.A.C value) {
 		_listener.beforeSet(this, AC__PROP, value);
 		_ac = value;
+		_listener.afterChanged(this, AC__PROP);
 	}
 
 	@Override
@@ -222,6 +223,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetBc(test.innertypeclash.B.C value) {
 		_listener.beforeSet(this, BC__PROP, value);
 		_bc = value;
+		_listener.afterChanged(this, BC__PROP);
 	}
 
 	@Override
@@ -244,6 +246,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetC(test.innertypeclash.A.C value) {
 		_listener.beforeSet(this, C__PROP, value);
 		_c = value;
+		_listener.afterChanged(this, C__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/innertypeclash/impl/B_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/innertypeclash/impl/B_Impl.java
@@ -200,6 +200,7 @@ public class B_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetAc(test.innertypeclash.A.C value) {
 		_listener.beforeSet(this, AC__PROP, value);
 		_ac = value;
+		_listener.afterChanged(this, AC__PROP);
 	}
 
 	@Override
@@ -222,6 +223,7 @@ public class B_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetBc(test.innertypeclash.B.C value) {
 		_listener.beforeSet(this, BC__PROP, value);
 		_bc = value;
+		_listener.afterChanged(this, BC__PROP);
 	}
 
 	@Override
@@ -244,6 +246,7 @@ public class B_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetC(test.innertypeclash.B.C value) {
 		_listener.beforeSet(this, C__PROP, value);
 		_c = value;
+		_listener.afterChanged(this, C__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/lowercasemessage/impl/A_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/lowercasemessage/impl/A_Impl.java
@@ -37,6 +37,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		protected final void internalSetA1(test.lowercasemessage.A value) {
 			_listener.beforeSet(this, A_1__PROP, value);
 			_a1 = value;
+			_listener.afterChanged(this, A_1__PROP);
 		}
 
 		@Override
@@ -59,6 +60,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		protected final void internalSetB1(test.lowercasemessage.A.B value) {
 			_listener.beforeSet(this, B_1__PROP, value);
 			_b1 = value;
+			_listener.afterChanged(this, B_1__PROP);
 		}
 
 		@Override
@@ -336,6 +338,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetA1(test.lowercasemessage.A value) {
 		_listener.beforeSet(this, A_1__PROP, value);
 		_a1 = value;
+		_listener.afterChanged(this, A_1__PROP);
 	}
 
 	@Override
@@ -358,6 +361,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetB1(test.lowercasemessage.A.B value) {
 		_listener.beforeSet(this, B_1__PROP, value);
 		_b1 = value;
+		_listener.afterChanged(this, B_1__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/maptype/data/impl/MyMessage_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/maptype/data/impl/MyMessage_Impl.java
@@ -15,6 +15,11 @@ public class MyMessage_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 		protected void afterRemove(String index, test.maptype.data.Project element) {
 			_listener.afterRemove(MyMessage_Impl.this, PROJECTS__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(MyMessage_Impl.this, PROJECTS__PROP);
+		}
 	};
 
 	private final java.util.Map<Integer, String> _rating = new de.haumacher.msgbuf.util.ReferenceMap<Integer, String>() {
@@ -26,6 +31,11 @@ public class MyMessage_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 		@Override
 		protected void afterRemove(Integer index, String element) {
 			_listener.afterRemove(MyMessage_Impl.this, RATING__PROP, index, element);
+		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(MyMessage_Impl.this, RATING__PROP);
 		}
 	};
 

--- a/de.haumacher.msgbuf.generator/src/test/java/test/maptype/data/impl/Project_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/maptype/data/impl/Project_Impl.java
@@ -33,6 +33,7 @@ public class Project_Impl extends de.haumacher.msgbuf.data.AbstractDataObject im
 	protected final void internalSetName(String value) {
 		_listener.beforeSet(this, NAME__PROP, value);
 		_name = value;
+		_listener.afterChanged(this, NAME__PROP);
 	}
 
 	@Override
@@ -50,6 +51,7 @@ public class Project_Impl extends de.haumacher.msgbuf.data.AbstractDataObject im
 	protected final void internalSetCost(double value) {
 		_listener.beforeSet(this, COST__PROP, value);
 		_cost = value;
+		_listener.afterChanged(this, COST__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nested/data/impl/SearchResponse_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nested/data/impl/SearchResponse_Impl.java
@@ -23,6 +23,11 @@ public class SearchResponse_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 			protected void afterRemove(int index, String element) {
 				_listener.afterRemove(Result_Impl.this, SNIPPETS__PROP, index, element);
 			}
+
+			@Override
+			protected void afterChanged() {
+				_listener.afterChanged(Result_Impl.this, SNIPPETS__PROP);
+			}
 		};
 
 		/**
@@ -49,6 +54,7 @@ public class SearchResponse_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 		protected final void internalSetUrl(String value) {
 			_listener.beforeSet(this, URL__PROP, value);
 			_url = value;
+			_listener.afterChanged(this, URL__PROP);
 		}
 
 		@Override
@@ -66,6 +72,7 @@ public class SearchResponse_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 		protected final void internalSetTitle(String value) {
 			_listener.beforeSet(this, TITLE__PROP, value);
 			_title = value;
+			_listener.afterChanged(this, TITLE__PROP);
 		}
 
 		@Override
@@ -393,6 +400,11 @@ public class SearchResponse_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 		@Override
 		protected void afterRemove(int index, test.nested.data.SearchResponse.Result element) {
 			_listener.afterRemove(SearchResponse_Impl.this, RESULTS__PROP, index, element);
+		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(SearchResponse_Impl.this, RESULTS__PROP);
 		}
 	};
 

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Car.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Car.java
@@ -75,6 +75,7 @@ public class Car extends Shape {
 	protected final void internalSetWheel1(test.nointerfaces.Circle value) {
 		_listener.beforeSet(this, WHEEL_1__PROP, value);
 		_wheel1 = value;
+		_listener.afterChanged(this, WHEEL_1__PROP);
 	}
 
 	/**
@@ -103,6 +104,7 @@ public class Car extends Shape {
 	protected final void internalSetWheel2(test.nointerfaces.Circle value) {
 		_listener.beforeSet(this, WHEEL_2__PROP, value);
 		_wheel2 = value;
+		_listener.afterChanged(this, WHEEL_2__PROP);
 	}
 
 	/**
@@ -131,6 +133,7 @@ public class Car extends Shape {
 	protected final void internalSetBody(test.nointerfaces.Rectangle value) {
 		_listener.beforeSet(this, BODY__PROP, value);
 		_body = value;
+		_listener.afterChanged(this, BODY__PROP);
 	}
 
 	/**

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Circle.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Circle.java
@@ -59,6 +59,7 @@ public class Circle extends AtomicShape {
 	protected final void internalSetRadius(int value) {
 		_listener.beforeSet(this, RADIUS__PROP, value);
 		_radius = value;
+		_listener.afterChanged(this, RADIUS__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Group.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Group.java
@@ -34,6 +34,11 @@ public class Group extends Shape {
 		protected void afterRemove(int index, test.nointerfaces.Shape element) {
 			_listener.afterRemove(Group.this, SHAPES__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(Group.this, SHAPES__PROP);
+		}
 	};
 
 	/**

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Rectangle.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Rectangle.java
@@ -73,6 +73,7 @@ public class Rectangle extends AtomicShape {
 	protected final void internalSetWidth(int value) {
 		_listener.beforeSet(this, WIDTH__PROP, value);
 		_width = value;
+		_listener.afterChanged(this, WIDTH__PROP);
 	}
 
 	/**
@@ -96,6 +97,7 @@ public class Rectangle extends AtomicShape {
 	protected final void internalSetHeight(int value) {
 		_listener.beforeSet(this, HEIGHT__PROP, value);
 		_height = value;
+		_listener.afterChanged(this, HEIGHT__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Shape.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Shape.java
@@ -79,6 +79,7 @@ public abstract class Shape extends de.haumacher.msgbuf.data.AbstractDataObject 
 	protected final void internalSetXCoordinate(int value) {
 		_listener.beforeSet(this, X_COORDINATE__PROP, value);
 		_xCoordinate = value;
+		_listener.afterChanged(this, X_COORDINATE__PROP);
 	}
 
 	/**
@@ -100,6 +101,7 @@ public abstract class Shape extends de.haumacher.msgbuf.data.AbstractDataObject 
 	protected final void internalSetYCoordinate(int value) {
 		_listener.beforeSet(this, Y_COORDINATE__PROP, value);
 		_yCoordinate = value;
+		_listener.afterChanged(this, Y_COORDINATE__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/SimpleType.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/SimpleType.java
@@ -59,6 +59,7 @@ public class SimpleType extends de.haumacher.msgbuf.data.AbstractDataObject impl
 	protected final void internalSetStr(String value) {
 		_listener.beforeSet(this, STR__PROP, value);
 		_str = value;
+		_listener.afterChanged(this, STR__PROP);
 	}
 
 	/**
@@ -80,6 +81,7 @@ public class SimpleType extends de.haumacher.msgbuf.data.AbstractDataObject impl
 	protected final void internalSetX(int value) {
 		_listener.beforeSet(this, X__PROP, value);
 		_x = value;
+		_listener.afterChanged(this, X__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Car_Impl.java
@@ -40,6 +40,7 @@ public class Car_Impl extends test.nojson.impl.Shape_Impl implements test.nojson
 	protected final void internalSetWheel1(test.nojson.Circle value) {
 		_listener.beforeSet(this, WHEEL_1__PROP, value);
 		_wheel1 = value;
+		_listener.afterChanged(this, WHEEL_1__PROP);
 	}
 
 	@Override
@@ -62,6 +63,7 @@ public class Car_Impl extends test.nojson.impl.Shape_Impl implements test.nojson
 	protected final void internalSetWheel2(test.nojson.Circle value) {
 		_listener.beforeSet(this, WHEEL_2__PROP, value);
 		_wheel2 = value;
+		_listener.afterChanged(this, WHEEL_2__PROP);
 	}
 
 	@Override
@@ -84,6 +86,7 @@ public class Car_Impl extends test.nojson.impl.Shape_Impl implements test.nojson
 	protected final void internalSetBody(test.nojson.Rectangle value) {
 		_listener.beforeSet(this, BODY__PROP, value);
 		_body = value;
+		_listener.afterChanged(this, BODY__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Circle_Impl.java
@@ -36,6 +36,7 @@ public class Circle_Impl extends test.nojson.impl.AtomicShape_Impl implements te
 	protected final void internalSetRadius(int value) {
 		_listener.beforeSet(this, RADIUS__PROP, value);
 		_radius = value;
+		_listener.afterChanged(this, RADIUS__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Group_Impl.java
@@ -15,6 +15,11 @@ public class Group_Impl extends test.nojson.impl.Shape_Impl implements test.nojs
 		protected void afterRemove(int index, test.nojson.Shape element) {
 			_listener.afterRemove(Group_Impl.this, SHAPES__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(Group_Impl.this, SHAPES__PROP);
+		}
 	};
 
 	/**

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Rectangle_Impl.java
@@ -38,6 +38,7 @@ public class Rectangle_Impl extends test.nojson.impl.AtomicShape_Impl implements
 	protected final void internalSetWidth(int value) {
 		_listener.beforeSet(this, WIDTH__PROP, value);
 		_width = value;
+		_listener.afterChanged(this, WIDTH__PROP);
 	}
 
 	@Override
@@ -55,6 +56,7 @@ public class Rectangle_Impl extends test.nojson.impl.AtomicShape_Impl implements
 	protected final void internalSetHeight(int value) {
 		_listener.beforeSet(this, HEIGHT__PROP, value);
 		_height = value;
+		_listener.afterChanged(this, HEIGHT__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Shape_Impl.java
@@ -31,6 +31,7 @@ public abstract class Shape_Impl implements test.nojson.Shape {
 	protected final void internalSetXCoordinate(int value) {
 		_listener.beforeSet(this, X_COORDINATE__PROP, value);
 		_xCoordinate = value;
+		_listener.afterChanged(this, X_COORDINATE__PROP);
 	}
 
 	@Override
@@ -48,6 +49,7 @@ public abstract class Shape_Impl implements test.nojson.Shape {
 	protected final void internalSetYCoordinate(int value) {
 		_listener.beforeSet(this, Y_COORDINATE__PROP, value);
 		_yCoordinate = value;
+		_listener.afterChanged(this, Y_COORDINATE__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/SimpleType_Impl.java
@@ -33,6 +33,7 @@ public class SimpleType_Impl implements test.nojson.SimpleType {
 	protected final void internalSetStr(String value) {
 		_listener.beforeSet(this, STR__PROP, value);
 		_str = value;
+		_listener.afterChanged(this, STR__PROP);
 	}
 
 	@Override
@@ -50,6 +51,7 @@ public class SimpleType_Impl implements test.nojson.SimpleType {
 	protected final void internalSetX(int value) {
 		_listener.beforeSet(this, X__PROP, value);
 		_x = value;
+		_listener.afterChanged(this, X__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Car_Impl.java
@@ -35,6 +35,7 @@ public class Car_Impl extends test.notypekind.impl.Shape_Impl implements test.no
 	protected final void internalSetWheel1(test.notypekind.Circle value) {
 		_listener.beforeSet(this, WHEEL_1__PROP, value);
 		_wheel1 = value;
+		_listener.afterChanged(this, WHEEL_1__PROP);
 	}
 
 	@Override
@@ -57,6 +58,7 @@ public class Car_Impl extends test.notypekind.impl.Shape_Impl implements test.no
 	protected final void internalSetWheel2(test.notypekind.Circle value) {
 		_listener.beforeSet(this, WHEEL_2__PROP, value);
 		_wheel2 = value;
+		_listener.afterChanged(this, WHEEL_2__PROP);
 	}
 
 	@Override
@@ -79,6 +81,7 @@ public class Car_Impl extends test.notypekind.impl.Shape_Impl implements test.no
 	protected final void internalSetBody(test.notypekind.Rectangle value) {
 		_listener.beforeSet(this, BODY__PROP, value);
 		_body = value;
+		_listener.afterChanged(this, BODY__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Circle_Impl.java
@@ -31,6 +31,7 @@ public class Circle_Impl extends test.notypekind.impl.AtomicShape_Impl implement
 	protected final void internalSetRadius(int value) {
 		_listener.beforeSet(this, RADIUS__PROP, value);
 		_radius = value;
+		_listener.afterChanged(this, RADIUS__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Group_Impl.java
@@ -15,6 +15,11 @@ public class Group_Impl extends test.notypekind.impl.Shape_Impl implements test.
 		protected void afterRemove(int index, test.notypekind.Shape element) {
 			_listener.afterRemove(Group_Impl.this, SHAPES__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(Group_Impl.this, SHAPES__PROP);
+		}
 	};
 
 	/**

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Rectangle_Impl.java
@@ -33,6 +33,7 @@ public class Rectangle_Impl extends test.notypekind.impl.AtomicShape_Impl implem
 	protected final void internalSetWidth(int value) {
 		_listener.beforeSet(this, WIDTH__PROP, value);
 		_width = value;
+		_listener.afterChanged(this, WIDTH__PROP);
 	}
 
 	@Override
@@ -50,6 +51,7 @@ public class Rectangle_Impl extends test.notypekind.impl.AtomicShape_Impl implem
 	protected final void internalSetHeight(int value) {
 		_listener.beforeSet(this, HEIGHT__PROP, value);
 		_height = value;
+		_listener.afterChanged(this, HEIGHT__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Shape_Impl.java
@@ -31,6 +31,7 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 	protected final void internalSetXCoordinate(int value) {
 		_listener.beforeSet(this, X_COORDINATE__PROP, value);
 		_xCoordinate = value;
+		_listener.afterChanged(this, X_COORDINATE__PROP);
 	}
 
 	@Override
@@ -48,6 +49,7 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 	protected final void internalSetYCoordinate(int value) {
 		_listener.beforeSet(this, Y_COORDINATE__PROP, value);
 		_yCoordinate = value;
+		_listener.afterChanged(this, Y_COORDINATE__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/SimpleType_Impl.java
@@ -33,6 +33,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	protected final void internalSetStr(String value) {
 		_listener.beforeSet(this, STR__PROP, value);
 		_str = value;
+		_listener.afterChanged(this, STR__PROP);
 	}
 
 	@Override
@@ -50,6 +51,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	protected final void internalSetX(int value) {
 		_listener.beforeSet(this, X__PROP, value);
 		_x = value;
+		_listener.afterChanged(this, X__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Car_Impl.java
@@ -40,6 +40,7 @@ public class Car_Impl extends test.novisit.impl.Shape_Impl implements test.novis
 	protected final void internalSetWheel1(test.novisit.Circle value) {
 		_listener.beforeSet(this, WHEEL_1__PROP, value);
 		_wheel1 = value;
+		_listener.afterChanged(this, WHEEL_1__PROP);
 	}
 
 	@Override
@@ -62,6 +63,7 @@ public class Car_Impl extends test.novisit.impl.Shape_Impl implements test.novis
 	protected final void internalSetWheel2(test.novisit.Circle value) {
 		_listener.beforeSet(this, WHEEL_2__PROP, value);
 		_wheel2 = value;
+		_listener.afterChanged(this, WHEEL_2__PROP);
 	}
 
 	@Override
@@ -84,6 +86,7 @@ public class Car_Impl extends test.novisit.impl.Shape_Impl implements test.novis
 	protected final void internalSetBody(test.novisit.Rectangle value) {
 		_listener.beforeSet(this, BODY__PROP, value);
 		_body = value;
+		_listener.afterChanged(this, BODY__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Circle_Impl.java
@@ -36,6 +36,7 @@ public class Circle_Impl extends test.novisit.impl.AtomicShape_Impl implements t
 	protected final void internalSetRadius(int value) {
 		_listener.beforeSet(this, RADIUS__PROP, value);
 		_radius = value;
+		_listener.afterChanged(this, RADIUS__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Group_Impl.java
@@ -15,6 +15,11 @@ public class Group_Impl extends test.novisit.impl.Shape_Impl implements test.nov
 		protected void afterRemove(int index, test.novisit.Shape element) {
 			_listener.afterRemove(Group_Impl.this, SHAPES__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(Group_Impl.this, SHAPES__PROP);
+		}
 	};
 
 	/**

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Rectangle_Impl.java
@@ -38,6 +38,7 @@ public class Rectangle_Impl extends test.novisit.impl.AtomicShape_Impl implement
 	protected final void internalSetWidth(int value) {
 		_listener.beforeSet(this, WIDTH__PROP, value);
 		_width = value;
+		_listener.afterChanged(this, WIDTH__PROP);
 	}
 
 	@Override
@@ -55,6 +56,7 @@ public class Rectangle_Impl extends test.novisit.impl.AtomicShape_Impl implement
 	protected final void internalSetHeight(int value) {
 		_listener.beforeSet(this, HEIGHT__PROP, value);
 		_height = value;
+		_listener.afterChanged(this, HEIGHT__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Shape_Impl.java
@@ -31,6 +31,7 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 	protected final void internalSetXCoordinate(int value) {
 		_listener.beforeSet(this, X_COORDINATE__PROP, value);
 		_xCoordinate = value;
+		_listener.afterChanged(this, X_COORDINATE__PROP);
 	}
 
 	@Override
@@ -48,6 +49,7 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 	protected final void internalSetYCoordinate(int value) {
 		_listener.beforeSet(this, Y_COORDINATE__PROP, value);
 		_yCoordinate = value;
+		_listener.afterChanged(this, Y_COORDINATE__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/SimpleType_Impl.java
@@ -33,6 +33,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	protected final void internalSetStr(String value) {
 		_listener.beforeSet(this, STR__PROP, value);
 		_str = value;
+		_listener.afterChanged(this, STR__PROP);
 	}
 
 	@Override
@@ -50,6 +51,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	protected final void internalSetX(int value) {
 		_listener.beforeSet(this, X__PROP, value);
 		_x = value;
+		_listener.afterChanged(this, X__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Car_Impl.java
@@ -40,6 +40,7 @@ public class Car_Impl extends test.novisitexceptions.impl.Shape_Impl implements 
 	protected final void internalSetWheel1(test.novisitexceptions.Circle value) {
 		_listener.beforeSet(this, WHEEL_1__PROP, value);
 		_wheel1 = value;
+		_listener.afterChanged(this, WHEEL_1__PROP);
 	}
 
 	@Override
@@ -62,6 +63,7 @@ public class Car_Impl extends test.novisitexceptions.impl.Shape_Impl implements 
 	protected final void internalSetWheel2(test.novisitexceptions.Circle value) {
 		_listener.beforeSet(this, WHEEL_2__PROP, value);
 		_wheel2 = value;
+		_listener.afterChanged(this, WHEEL_2__PROP);
 	}
 
 	@Override
@@ -84,6 +86,7 @@ public class Car_Impl extends test.novisitexceptions.impl.Shape_Impl implements 
 	protected final void internalSetBody(test.novisitexceptions.Rectangle value) {
 		_listener.beforeSet(this, BODY__PROP, value);
 		_body = value;
+		_listener.afterChanged(this, BODY__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Circle_Impl.java
@@ -36,6 +36,7 @@ public class Circle_Impl extends test.novisitexceptions.impl.AtomicShape_Impl im
 	protected final void internalSetRadius(int value) {
 		_listener.beforeSet(this, RADIUS__PROP, value);
 		_radius = value;
+		_listener.afterChanged(this, RADIUS__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Group_Impl.java
@@ -15,6 +15,11 @@ public class Group_Impl extends test.novisitexceptions.impl.Shape_Impl implement
 		protected void afterRemove(int index, test.novisitexceptions.Shape element) {
 			_listener.afterRemove(Group_Impl.this, SHAPES__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(Group_Impl.this, SHAPES__PROP);
+		}
 	};
 
 	/**

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Rectangle_Impl.java
@@ -38,6 +38,7 @@ public class Rectangle_Impl extends test.novisitexceptions.impl.AtomicShape_Impl
 	protected final void internalSetWidth(int value) {
 		_listener.beforeSet(this, WIDTH__PROP, value);
 		_width = value;
+		_listener.afterChanged(this, WIDTH__PROP);
 	}
 
 	@Override
@@ -55,6 +56,7 @@ public class Rectangle_Impl extends test.novisitexceptions.impl.AtomicShape_Impl
 	protected final void internalSetHeight(int value) {
 		_listener.beforeSet(this, HEIGHT__PROP, value);
 		_height = value;
+		_listener.afterChanged(this, HEIGHT__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Shape_Impl.java
@@ -31,6 +31,7 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 	protected final void internalSetXCoordinate(int value) {
 		_listener.beforeSet(this, X_COORDINATE__PROP, value);
 		_xCoordinate = value;
+		_listener.afterChanged(this, X_COORDINATE__PROP);
 	}
 
 	@Override
@@ -48,6 +49,7 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 	protected final void internalSetYCoordinate(int value) {
 		_listener.beforeSet(this, Y_COORDINATE__PROP, value);
 		_yCoordinate = value;
+		_listener.afterChanged(this, Y_COORDINATE__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/SimpleType_Impl.java
@@ -33,6 +33,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	protected final void internalSetStr(String value) {
 		_listener.beforeSet(this, STR__PROP, value);
 		_str = value;
+		_listener.afterChanged(this, STR__PROP);
 	}
 
 	@Override
@@ -50,6 +51,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	protected final void internalSetX(int value) {
 		_listener.beforeSet(this, X__PROP, value);
 		_x = value;
+		_listener.afterChanged(this, X__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/references/data/impl/A_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/references/data/impl/A_Impl.java
@@ -19,6 +19,11 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		protected void afterRemove(int index, test.references.data.A element) {
 			_listener.afterRemove(A_Impl.this, CHILDREN__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(A_Impl.this, CHILDREN__PROP);
+		}
 	};
 
 	private final java.util.List<test.references.data.B> _bs = new de.haumacher.msgbuf.util.ReferenceList<test.references.data.B>() {
@@ -34,6 +39,11 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 			test.references.data.impl.B_Impl removed = (test.references.data.impl.B_Impl) element;
 			removed.removeInBs(A_Impl.this);
 			_listener.afterRemove(A_Impl.this, BS__PROP, index, element);
+		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(A_Impl.this, BS__PROP);
 		}
 	};
 
@@ -55,6 +65,11 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 			removed.removeInOthers(A_Impl.this);
 			_listener.afterRemove(A_Impl.this, OTHERS__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(A_Impl.this, OTHERS__PROP);
+		}
 	};
 
 	private final java.util.List<test.references.data.A> _inOther = new de.haumacher.msgbuf.util.ReferenceList<test.references.data.A>() {
@@ -67,6 +82,11 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		protected void afterRemove(int index, test.references.data.A element) {
 			_listener.afterRemove(A_Impl.this, IN_OTHER__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(A_Impl.this, IN_OTHER__PROP);
+		}
 	};
 
 	private final java.util.List<test.references.data.A> _inOthers = new de.haumacher.msgbuf.util.ReferenceList<test.references.data.A>() {
@@ -78,6 +98,11 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		@Override
 		protected void afterRemove(int index, test.references.data.A element) {
 			_listener.afterRemove(A_Impl.this, IN_OTHERS__PROP, index, element);
+		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(A_Impl.this, IN_OTHERS__PROP);
 		}
 	};
 
@@ -105,6 +130,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetName(String value) {
 		_listener.beforeSet(this, NAME__PROP, value);
 		_name = value;
+		_listener.afterChanged(this, NAME__PROP);
 	}
 
 	@Override
@@ -122,6 +148,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetContents(test.references.data.A value) {
 		_listener.beforeSet(this, CONTENTS__PROP, value);
 		_contents = value;
+		_listener.afterChanged(this, CONTENTS__PROP);
 	}
 
 	@Override
@@ -220,6 +247,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		if (after != null) {
 			after.addInB(this);
 		}
+		_listener.afterChanged(this, B__PROP);
 	}
 
 	@Override
@@ -250,6 +278,7 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		if (after != null) {
 			after.addInOther(this);
 		}
+		_listener.afterChanged(this, OTHER__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/references/data/impl/B_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/references/data/impl/B_Impl.java
@@ -17,6 +17,11 @@ public class B_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		protected void afterRemove(int index, test.references.data.A element) {
 			_listener.afterRemove(B_Impl.this, IN_BS__PROP, index, element);
 		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(B_Impl.this, IN_BS__PROP);
+		}
 	};
 
 	private final java.util.List<test.references.data.A> _inB = new de.haumacher.msgbuf.util.ReferenceList<test.references.data.A>() {
@@ -28,6 +33,11 @@ public class B_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		@Override
 		protected void afterRemove(int index, test.references.data.A element) {
 			_listener.afterRemove(B_Impl.this, IN_B__PROP, index, element);
+		}
+
+		@Override
+		protected void afterChanged() {
+			_listener.afterChanged(B_Impl.this, IN_B__PROP);
 		}
 	};
 
@@ -55,6 +65,7 @@ public class B_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 	protected final void internalSetName(String value) {
 		_listener.beforeSet(this, NAME__PROP, value);
 		_name = value;
+		_listener.afterChanged(this, NAME__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/types/data/impl/SearchRequest_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/types/data/impl/SearchRequest_Impl.java
@@ -35,6 +35,7 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 	protected final void internalSetQuery(String value) {
 		_listener.beforeSet(this, QUERY__PROP, value);
 		_query = value;
+		_listener.afterChanged(this, QUERY__PROP);
 	}
 
 	@Override
@@ -52,6 +53,7 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 	protected final void internalSetPageNumber(int value) {
 		_listener.beforeSet(this, PAGE_NUMBER__PROP, value);
 		_pageNumber = value;
+		_listener.afterChanged(this, PAGE_NUMBER__PROP);
 	}
 
 	@Override
@@ -69,6 +71,7 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 	protected final void internalSetResultPerPage(int value) {
 		_listener.beforeSet(this, RESULT_PER_PAGE__PROP, value);
 		_resultPerPage = value;
+		_listener.afterChanged(this, RESULT_PER_PAGE__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;

--- a/de.haumacher.msgbuf.generator/src/test/java/test/underscorename/impl/AnnotatedMessage_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/underscorename/impl/AnnotatedMessage_Impl.java
@@ -36,6 +36,7 @@ public class AnnotatedMessage_Impl extends test.underscorename.impl.BaseMsg_Impl
 	protected final void internalSetAnnotatedField(String value) {
 		_listener.beforeSet(this, ANNOTATED_FIELD__PROP, value);
 		_annotatedField = value;
+		_listener.afterChanged(this, ANNOTATED_FIELD__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf.generator/src/test/java/test/underscorename/impl/SomeName_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/underscorename/impl/SomeName_Impl.java
@@ -36,6 +36,7 @@ public class SomeName_Impl extends test.underscorename.impl.BaseMsg_Impl impleme
 	protected final void internalSetMyField(String value) {
 		_listener.beforeSet(this, MY_FIELD__PROP, value);
 		_myField = value;
+		_listener.afterChanged(this, MY_FIELD__PROP);
 	}
 
 	@Override

--- a/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/observer/Listener.java
+++ b/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/observer/Listener.java
@@ -96,6 +96,25 @@ public interface Listener {
 		// Ignore.
 	}
 	
+	/** 
+	 * Informs this {@link Listener} that the property of an element was changed.
+	 * 
+	 * <p>
+	 * This method is also called after all other methods to indicate that a property has been changed. It is not 
+	 * called more than once for bulk operations (e.g. adding several objects to a list)
+	 * </p>
+	 * 
+	 * @param obj
+	 *        The {@link Observable} object.
+	 * @param property
+	 *        The name of the property to be modified.
+	 */
+	default void afterChanged(Observable obj, String property) {
+		// Ignore.
+	}
+	
+	
+	
 	/**
 	 * {@link Listener} that multiplexes events to a list of potentially multiple target {@link Listener}s.
 	 */
@@ -128,6 +147,13 @@ public interface Listener {
 		public void afterRemove(Observable obj, String property, int index, Object element) {
 			for (Listener l : current()) {
 				l.afterRemove(obj, property, index, element);
+			}
+		}
+		
+		@Override
+		public void afterChanged(Observable obj, String property) {
+			for (Listener l : current()) {
+				l.afterChanged(obj, property);
 			}
 		}
 

--- a/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/util/ReferenceList.java
+++ b/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/util/ReferenceList.java
@@ -23,24 +23,37 @@ public abstract class ReferenceList<T> extends ArrayList<T> {
 	public void add(int index, T element) {
 		beforeAdd(index, element);
 		super.add(index, element);
+		afterChanged();
 	}
 
 	@Override
 	public boolean add(T element) {
 		beforeAdd(size(), element);
-		return super.add(element);
+		boolean changed = super.add(element);
+		if (changed) {
+			afterChanged();
+		}
+		return changed;
 	}
 
 	@Override
 	public boolean addAll(Collection<? extends T> collection) {
 		beforeAddAll(size(), collection);
-		return super.addAll(collection);
+		boolean changed = super.addAll(collection);
+		if (changed) {
+			afterChanged();
+		}
+		return changed;
 	}
 
 	@Override
 	public boolean addAll(int index, Collection<? extends T> collection) {
 		beforeAddAll(index, collection);
-		return super.addAll(index, collection);
+		boolean changed = super.addAll(index, collection);
+		if (changed) {
+			afterChanged();
+		}
+		return changed;
 	}
 
 	private void beforeAddAll(int index, Collection<? extends T> collection) {
@@ -53,6 +66,12 @@ public abstract class ReferenceList<T> extends ArrayList<T> {
 
 	@Override
 	public T remove(int index) {
+		T removed = internalRemove(index);
+		afterChanged();
+		return removed;
+	}
+
+	private T internalRemove(int index) {
 		T removed = super.remove(index);
 		afterRemove(index, removed);
 		return removed;
@@ -63,8 +82,8 @@ public abstract class ReferenceList<T> extends ArrayList<T> {
 		int index = super.indexOf(element);
 		boolean success = index >= 0;
 		if (success) {
-			final T removed = super.remove(index);
-			afterRemove(index, removed);
+			internalRemove(index);
+			afterChanged();
 		}
 		return success;
 	}
@@ -81,9 +100,14 @@ public abstract class ReferenceList<T> extends ArrayList<T> {
 
 	@Override
 	public void clear() {
-		for (int index = size() - 1; index >= 0; index--) {
-			remove(index);
+		int size = size();
+		if (size == 0) {
+			return;
 		}
+		for (int index = size - 1; index >= 0; index--) {
+			internalRemove(index);
+		}
+		afterChanged();
 	}
 
 	/**
@@ -98,9 +122,12 @@ public abstract class ReferenceList<T> extends ArrayList<T> {
 		for (int index = size() - 1; index >= 0; index--) {
 			T element = get(index);
 			if (test.contains(element) == removePresent) {
-				remove(index);
+				internalRemove(index);
 				changed = true;
 			}
+		}
+		if (changed) {
+			afterChanged();
 		}
 		return changed;
 	}
@@ -112,7 +139,11 @@ public abstract class ReferenceList<T> extends ArrayList<T> {
 		beforeAdd(index, element);
 		T oldValue = super.set(index, element);
 		afterRemove(index + 1, oldValue);
+		afterChanged();
 		return oldValue;
 	}
 
+	protected void afterChanged() {
+		// empty for compatibility.
+	}
 }

--- a/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/util/ReferenceList.java
+++ b/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/util/ReferenceList.java
@@ -33,18 +33,17 @@ public abstract class ReferenceList<T> extends ArrayList<T> {
 
 	@Override
 	public boolean addAll(Collection<? extends T> collection) {
-		beforeAddAll(collection);
+		beforeAddAll(size(), collection);
 		return super.addAll(collection);
 	}
 
 	@Override
 	public boolean addAll(int index, Collection<? extends T> collection) {
-		beforeAddAll(collection);
+		beforeAddAll(index, collection);
 		return super.addAll(index, collection);
 	}
 
-	private void beforeAddAll(Collection<? extends T> collection) {
-		int index = size();
+	private void beforeAddAll(int index, Collection<? extends T> collection) {
 		for (T element : collection) {
 			beforeAdd(index++, element);
 		}

--- a/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/util/ReferenceMap.java
+++ b/de.haumacher.msgbuf/src/main/java/de/haumacher/msgbuf/util/ReferenceMap.java
@@ -19,10 +19,11 @@ public abstract class ReferenceMap<K, V> extends HashMap<K, V> {
 
 	@Override
 	public V put(K key, V value) {
-		remove(key);
+		V oldValue = remove(key);
 		
 		beforeAdd(key, value);
-		return super.put(key, value);
+		super.put(key, value);
+		return oldValue; 
 	}
 
 	@Override


### PR DESCRIPTION
The class de.haumacher.msgbuf.observer.Listener gets a new method "afterChanged(Observable, String)" to inform that the value of a property has changed.

The method may not be called on each atomic call, e.g. when adding multiple elements to a list-valued property, the listener is called once.