### PR TITLE
Fix transient inheritance

### DIFF
--- a/de.haumacher.msgbuf.generator/src/test/java/test/comments/data/impl/SearchRequest_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/comments/data/impl/SearchRequest_Impl.java
@@ -101,15 +101,22 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 		return SEARCH_REQUEST__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			QUERY__PROP, 
 			PAGE_NUMBER__PROP, 
-			RESULT_PER_PAGE__PROP));
+			RESULT_PER_PAGE__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/container/model/impl/MyContainer_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/container/model/impl/MyContainer_Impl.java
@@ -336,19 +336,26 @@ public class MyContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataObjec
 		return MY_CONTAINER__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			NAME__PROP, 
 			CONTENT_1__PROP, 
 			CONTENT_2__PROP, 
 			CONTENT_LIST__PROP, 
 			CONTENT_MAP__PROP, 
 			OTHER__PROP, 
-			OTHERS__PROP));
+			OTHERS__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/container/model/impl/MyContent_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/container/model/impl/MyContent_Impl.java
@@ -91,14 +91,21 @@ public class MyContent_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 		return MY_CONTENT__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			CONTAINER__PROP, 
-			NAME__PROP));
+			NAME__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/container/nointerfaces/model/MyContainer.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/container/nointerfaces/model/MyContainer.java
@@ -410,19 +410,26 @@ public class MyContainer extends de.haumacher.msgbuf.data.AbstractDataObject imp
 		return MY_CONTAINER__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			NAME__PROP, 
 			CONTENT_1__PROP, 
 			CONTENT_2__PROP, 
 			CONTENT_LIST__PROP, 
 			CONTENT_MAP__PROP, 
 			OTHER__PROP, 
-			OTHERS__PROP));
+			OTHERS__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/container/nointerfaces/model/MyContent.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/container/nointerfaces/model/MyContent.java
@@ -109,14 +109,21 @@ public class MyContent extends de.haumacher.msgbuf.data.AbstractDataObject imple
 		return MY_CONTENT__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			CONTAINER__PROP, 
-			NAME__PROP));
+			NAME__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/defaultvalue/data/impl/A_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/defaultvalue/data/impl/A_Impl.java
@@ -121,16 +121,23 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		return A__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			S__PROP, 
 			X__PROP, 
 			Y__PROP, 
-			STATE__PROP));
+			STATE__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/Container_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/Container_Impl.java
@@ -112,14 +112,21 @@ public class Container_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 		return CONTAINER__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			NAME__PROP, 
-			CONTENTS__PROP));
+			CONTENTS__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/EmbeddingContainer_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/EmbeddingContainer_Impl.java
@@ -112,14 +112,21 @@ public class EmbeddingContainer_Impl extends de.haumacher.msgbuf.data.AbstractDa
 		return EMBEDDING_CONTAINER__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			NAME__PROP, 
-			CONTENTS__PROP));
+			CONTENTS__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/EmbeddingSingleContainer_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/EmbeddingSingleContainer_Impl.java
@@ -86,14 +86,21 @@ public class EmbeddingSingleContainer_Impl extends de.haumacher.msgbuf.data.Abst
 		return EMBEDDING_SINGLE_CONTAINER__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			NAME__PROP, 
-			CONTENTS__PROP));
+			CONTENTS__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/SingleContainer_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/embedded/data/impl/SingleContainer_Impl.java
@@ -86,14 +86,21 @@ public class SingleContainer_Impl extends de.haumacher.msgbuf.data.AbstractDataO
 		return SINGLE_CONTAINER__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			NAME__PROP, 
-			CONTENTS__PROP));
+			CONTENTS__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/enumeration/data/impl/SearchRequest_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/enumeration/data/impl/SearchRequest_Impl.java
@@ -122,16 +122,23 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 		return SEARCH_REQUEST__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			QUERY__PROP, 
 			PAGE_NUMBER__PROP, 
 			RESULT_PER_PAGE__PROP, 
-			CORPUS__PROP));
+			CORPUS__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Car_Impl.java
@@ -111,15 +111,28 @@ public class Car_Impl extends test.graph.data.impl.Shape_Impl implements test.gr
 		return CAR__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WHEEL_1__PROP, 
 			WHEEL_2__PROP, 
-			BODY__PROP));
+			BODY__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.graph.data.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.graph.data.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Circle_Impl.java
@@ -56,13 +56,26 @@ public class Circle_Impl extends test.graph.data.impl.AtomicShape_Impl implement
 		return CIRCLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			RADIUS__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			RADIUS__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.graph.data.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.graph.data.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Group_Impl.java
@@ -87,13 +87,26 @@ public class Group_Impl extends test.graph.data.impl.Shape_Impl implements test.
 		return GROUP__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			SHAPES__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			SHAPES__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.graph.data.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.graph.data.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Rectangle_Impl.java
@@ -76,14 +76,27 @@ public class Rectangle_Impl extends test.graph.data.impl.AtomicShape_Impl implem
 		return RECTANGLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WIDTH__PROP, 
-			HEIGHT__PROP));
+			HEIGHT__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.graph.data.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.graph.data.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/Shape_Impl.java
@@ -52,14 +52,21 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.graph.AbstractShare
 		_listener.afterChanged(this, Y_COORDINATE__PROP);
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			X_COORDINATE__PROP, 
-			Y_COORDINATE__PROP));
+			Y_COORDINATE__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/graph/data/impl/SimpleType_Impl.java
@@ -59,14 +59,21 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.graph.AbstractSharedGra
 		return SIMPLE_TYPE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			STR__PROP, 
-			X__PROP));
+			X__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Car_Impl.java
@@ -117,15 +117,28 @@ public class Car_Impl extends test.hierarchy.data.impl.Shape_Impl implements tes
 		return CAR__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WHEEL_1__PROP, 
 			WHEEL_2__PROP, 
-			BODY__PROP));
+			BODY__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.hierarchy.data.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.hierarchy.data.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Circle_Impl.java
@@ -62,13 +62,26 @@ public class Circle_Impl extends test.hierarchy.data.impl.AtomicShape_Impl imple
 		return CIRCLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			RADIUS__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			RADIUS__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.hierarchy.data.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.hierarchy.data.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Group_Impl.java
@@ -93,13 +93,26 @@ public class Group_Impl extends test.hierarchy.data.impl.Shape_Impl implements t
 		return GROUP__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			SHAPES__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			SHAPES__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.hierarchy.data.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.hierarchy.data.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Optional_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Optional_Impl.java
@@ -87,14 +87,27 @@ public class Optional_Impl extends test.hierarchy.data.impl.Shape_Impl implement
 		return OPTIONAL__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			HIDDEN__PROP, 
-			SHAPE__PROP));
+			SHAPE__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.hierarchy.data.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.hierarchy.data.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Rectangle_Impl.java
@@ -82,14 +82,27 @@ public class Rectangle_Impl extends test.hierarchy.data.impl.AtomicShape_Impl im
 		return RECTANGLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WIDTH__PROP, 
-			HEIGHT__PROP));
+			HEIGHT__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.hierarchy.data.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.hierarchy.data.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/Shape_Impl.java
@@ -95,15 +95,22 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 		_listener = de.haumacher.msgbuf.observer.Listener.unregister(_listener, l);
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			X_COORDINATE__PROP, 
 			Y_COORDINATE__PROP, 
-			COLOR__PROP));
+			COLOR__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/hierarchy/data/impl/SimpleType_Impl.java
@@ -81,14 +81,21 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 		return SIMPLE_TYPE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			STR__PROP, 
-			X__PROP));
+			X__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/innertypeclash/impl/A_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/innertypeclash/impl/A_Impl.java
@@ -281,15 +281,22 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		return A__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			AC__PROP, 
 			BC__PROP, 
-			C__PROP));
+			C__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/innertypeclash/impl/B_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/innertypeclash/impl/B_Impl.java
@@ -281,15 +281,22 @@ public class B_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		return B__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			AC__PROP, 
 			BC__PROP, 
-			C__PROP));
+			C__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/lowercasemessage/impl/A_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/lowercasemessage/impl/A_Impl.java
@@ -95,14 +95,21 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 			return B__TYPE;
 		}
 
-		private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-			java.util.Arrays.asList(
+		static final java.util.List<String> PROPERTIES;
+		static {
+			java.util.List<String> local = java.util.Arrays.asList(
 				A_1__PROP, 
-				B_1__PROP));
+				B_1__PROP);
+			PROPERTIES = java.util.Collections.unmodifiableList(local);
+		}
 
-		private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-				java.util.Arrays.asList(
-					)));
+		static final java.util.Set<String> TRANSIENT_PROPERTIES;
+		static {
+			java.util.HashSet<String> tmp = new java.util.HashSet<>();
+			tmp.addAll(java.util.Arrays.asList(
+					));
+			TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+		}
 
 		@Override
 		public java.util.List<String> properties() {
@@ -396,14 +403,21 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		return A__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			A_1__PROP, 
-			B_1__PROP));
+			B_1__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/maptype/data/impl/MyMessage_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/maptype/data/impl/MyMessage_Impl.java
@@ -149,14 +149,21 @@ public class MyMessage_Impl extends de.haumacher.msgbuf.data.AbstractDataObject 
 		return MY_MESSAGE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			PROJECTS__PROP, 
-			RATING__PROP));
+			RATING__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/maptype/data/impl/Project_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/maptype/data/impl/Project_Impl.java
@@ -81,14 +81,21 @@ public class Project_Impl extends de.haumacher.msgbuf.data.AbstractDataObject im
 		return PROJECT__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			NAME__PROP, 
-			COST__PROP));
+			COST__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nested/data/impl/SearchResponse_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nested/data/impl/SearchResponse_Impl.java
@@ -135,15 +135,22 @@ public class SearchResponse_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 			return RESULT__TYPE;
 		}
 
-		private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-			java.util.Arrays.asList(
+		static final java.util.List<String> PROPERTIES;
+		static {
+			java.util.List<String> local = java.util.Arrays.asList(
 				URL__PROP, 
 				TITLE__PROP, 
-				SNIPPETS__PROP));
+				SNIPPETS__PROP);
+			PROPERTIES = java.util.Collections.unmodifiableList(local);
+		}
 
-		private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-				java.util.Arrays.asList(
-					)));
+		static final java.util.Set<String> TRANSIENT_PROPERTIES;
+		static {
+			java.util.HashSet<String> tmp = new java.util.HashSet<>();
+			tmp.addAll(java.util.Arrays.asList(
+					));
+			TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+		}
 
 		@Override
 		public java.util.List<String> properties() {
@@ -478,13 +485,20 @@ public class SearchResponse_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 		return SEARCH_RESPONSE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			RESULTS__PROP));
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			RESULTS__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Car.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Car.java
@@ -160,15 +160,28 @@ public class Car extends Shape {
 		return CAR__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WHEEL_1__PROP, 
 			WHEEL_2__PROP, 
-			BODY__PROP));
+			BODY__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nointerfaces.Shape.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nointerfaces.Shape.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Circle.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Circle.java
@@ -79,13 +79,26 @@ public class Circle extends AtomicShape {
 		return CIRCLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			RADIUS__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			RADIUS__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nointerfaces.Shape.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nointerfaces.Shape.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Group.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Group.java
@@ -118,13 +118,26 @@ public class Group extends Shape {
 		return GROUP__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			SHAPES__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			SHAPES__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nointerfaces.Shape.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nointerfaces.Shape.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Rectangle.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Rectangle.java
@@ -117,14 +117,27 @@ public class Rectangle extends AtomicShape {
 		return RECTANGLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WIDTH__PROP, 
-			HEIGHT__PROP));
+			HEIGHT__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nointerfaces.Shape.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nointerfaces.Shape.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Shape.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/Shape.java
@@ -126,14 +126,21 @@ public abstract class Shape extends de.haumacher.msgbuf.data.AbstractDataObject 
 		_listener = de.haumacher.msgbuf.observer.Listener.unregister(_listener, l);
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			X_COORDINATE__PROP, 
-			Y_COORDINATE__PROP));
+			Y_COORDINATE__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/SimpleType.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nointerfaces/SimpleType.java
@@ -111,14 +111,21 @@ public class SimpleType extends de.haumacher.msgbuf.data.AbstractDataObject impl
 		return SIMPLE_TYPE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			STR__PROP, 
-			X__PROP));
+			X__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Car_Impl.java
@@ -111,15 +111,28 @@ public class Car_Impl extends test.nojson.impl.Shape_Impl implements test.nojson
 		return CAR__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WHEEL_1__PROP, 
 			WHEEL_2__PROP, 
-			BODY__PROP));
+			BODY__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nojson.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nojson.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Circle_Impl.java
@@ -56,13 +56,26 @@ public class Circle_Impl extends test.nojson.impl.AtomicShape_Impl implements te
 		return CIRCLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			RADIUS__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			RADIUS__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nojson.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nojson.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Group_Impl.java
@@ -87,13 +87,26 @@ public class Group_Impl extends test.nojson.impl.Shape_Impl implements test.nojs
 		return GROUP__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			SHAPES__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			SHAPES__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nojson.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nojson.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Rectangle_Impl.java
@@ -76,14 +76,27 @@ public class Rectangle_Impl extends test.nojson.impl.AtomicShape_Impl implements
 		return RECTANGLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WIDTH__PROP, 
-			HEIGHT__PROP));
+			HEIGHT__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nojson.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nojson.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/Shape_Impl.java
@@ -74,14 +74,21 @@ public abstract class Shape_Impl implements test.nojson.Shape {
 		_listener = de.haumacher.msgbuf.observer.Listener.unregister(_listener, l);
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			X_COORDINATE__PROP, 
-			Y_COORDINATE__PROP));
+			Y_COORDINATE__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nojson/impl/SimpleType_Impl.java
@@ -81,14 +81,21 @@ public class SimpleType_Impl implements test.nojson.SimpleType {
 		return SIMPLE_TYPE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			STR__PROP, 
-			X__PROP));
+			X__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Car_Impl.java
@@ -105,15 +105,28 @@ public class Car_Impl extends test.nolistener.impl.Shape_Impl implements test.no
 		return CAR__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WHEEL_1__PROP, 
 			WHEEL_2__PROP, 
-			BODY__PROP));
+			BODY__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nolistener.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nolistener.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Circle_Impl.java
@@ -54,13 +54,26 @@ public class Circle_Impl extends test.nolistener.impl.AtomicShape_Impl implement
 		return CIRCLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			RADIUS__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			RADIUS__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nolistener.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nolistener.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Group_Impl.java
@@ -72,13 +72,26 @@ public class Group_Impl extends test.nolistener.impl.Shape_Impl implements test.
 		return GROUP__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			SHAPES__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			SHAPES__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nolistener.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nolistener.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Rectangle_Impl.java
@@ -72,14 +72,27 @@ public class Rectangle_Impl extends test.nolistener.impl.AtomicShape_Impl implem
 		return RECTANGLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WIDTH__PROP, 
-			HEIGHT__PROP));
+			HEIGHT__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.nolistener.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.nolistener.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/Shape_Impl.java
@@ -48,14 +48,21 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 		_yCoordinate = value;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			X_COORDINATE__PROP, 
-			Y_COORDINATE__PROP));
+			Y_COORDINATE__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nolistener/impl/SimpleType_Impl.java
@@ -55,14 +55,21 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 		return SIMPLE_TYPE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			STR__PROP, 
-			X__PROP));
+			X__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Car_Impl.java
@@ -106,15 +106,28 @@ public class Car_Impl extends test.notypekind.impl.Shape_Impl implements test.no
 		return CAR__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WHEEL_1__PROP, 
 			WHEEL_2__PROP, 
-			BODY__PROP));
+			BODY__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.notypekind.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.notypekind.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Circle_Impl.java
@@ -51,13 +51,26 @@ public class Circle_Impl extends test.notypekind.impl.AtomicShape_Impl implement
 		return CIRCLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			RADIUS__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			RADIUS__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.notypekind.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.notypekind.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Group_Impl.java
@@ -82,13 +82,26 @@ public class Group_Impl extends test.notypekind.impl.Shape_Impl implements test.
 		return GROUP__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			SHAPES__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			SHAPES__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.notypekind.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.notypekind.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Rectangle_Impl.java
@@ -71,14 +71,27 @@ public class Rectangle_Impl extends test.notypekind.impl.AtomicShape_Impl implem
 		return RECTANGLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WIDTH__PROP, 
-			HEIGHT__PROP));
+			HEIGHT__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.notypekind.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.notypekind.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/Shape_Impl.java
@@ -74,14 +74,21 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 		_listener = de.haumacher.msgbuf.observer.Listener.unregister(_listener, l);
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			X_COORDINATE__PROP, 
-			Y_COORDINATE__PROP));
+			Y_COORDINATE__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/notypekind/impl/SimpleType_Impl.java
@@ -81,14 +81,21 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 		return SIMPLE_TYPE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			STR__PROP, 
-			X__PROP));
+			X__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Car_Impl.java
@@ -111,15 +111,28 @@ public class Car_Impl extends test.novisit.impl.Shape_Impl implements test.novis
 		return CAR__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WHEEL_1__PROP, 
 			WHEEL_2__PROP, 
-			BODY__PROP));
+			BODY__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.novisit.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.novisit.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Circle_Impl.java
@@ -56,13 +56,26 @@ public class Circle_Impl extends test.novisit.impl.AtomicShape_Impl implements t
 		return CIRCLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			RADIUS__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			RADIUS__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.novisit.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.novisit.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Group_Impl.java
@@ -87,13 +87,26 @@ public class Group_Impl extends test.novisit.impl.Shape_Impl implements test.nov
 		return GROUP__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			SHAPES__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			SHAPES__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.novisit.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.novisit.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Rectangle_Impl.java
@@ -76,14 +76,27 @@ public class Rectangle_Impl extends test.novisit.impl.AtomicShape_Impl implement
 		return RECTANGLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WIDTH__PROP, 
-			HEIGHT__PROP));
+			HEIGHT__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.novisit.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.novisit.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisit/impl/Shape_Impl.java
@@ -74,14 +74,21 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 		_listener = de.haumacher.msgbuf.observer.Listener.unregister(_listener, l);
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			X_COORDINATE__PROP, 
-			Y_COORDINATE__PROP));
+			Y_COORDINATE__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Car_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Car_Impl.java
@@ -111,15 +111,28 @@ public class Car_Impl extends test.novisitexceptions.impl.Shape_Impl implements 
 		return CAR__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WHEEL_1__PROP, 
 			WHEEL_2__PROP, 
-			BODY__PROP));
+			BODY__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.novisitexceptions.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.novisitexceptions.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Circle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Circle_Impl.java
@@ -56,13 +56,26 @@ public class Circle_Impl extends test.novisitexceptions.impl.AtomicShape_Impl im
 		return CIRCLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			RADIUS__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			RADIUS__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.novisitexceptions.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.novisitexceptions.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Group_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Group_Impl.java
@@ -87,13 +87,26 @@ public class Group_Impl extends test.novisitexceptions.impl.Shape_Impl implement
 		return GROUP__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			SHAPES__PROP));
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			SHAPES__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.novisitexceptions.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.novisitexceptions.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Rectangle_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Rectangle_Impl.java
@@ -76,14 +76,27 @@ public class Rectangle_Impl extends test.novisitexceptions.impl.AtomicShape_Impl
 		return RECTANGLE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			WIDTH__PROP, 
-			HEIGHT__PROP));
+			HEIGHT__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.novisitexceptions.impl.Shape_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.novisitexceptions.impl.Shape_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Shape_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/Shape_Impl.java
@@ -74,14 +74,21 @@ public abstract class Shape_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 		_listener = de.haumacher.msgbuf.observer.Listener.unregister(_listener, l);
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			X_COORDINATE__PROP, 
-			Y_COORDINATE__PROP));
+			Y_COORDINATE__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/SimpleType_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/novisitexceptions/impl/SimpleType_Impl.java
@@ -81,14 +81,21 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 		return SIMPLE_TYPE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			STR__PROP, 
-			X__PROP));
+			X__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/nullable/data/impl/NullableValues_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/nullable/data/impl/NullableValues_Impl.java
@@ -266,8 +266,9 @@ public class NullableValues_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 		return NULLABLE_VALUES__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			INT__PROP, 
 			LONG__PROP, 
 			BOOLEAN__PROP, 
@@ -275,11 +276,17 @@ public class NullableValues_Impl extends de.haumacher.msgbuf.data.AbstractDataOb
 			INT_LIST__PROP, 
 			STRING_LIST__PROP, 
 			STRING_INT_MAP__PROP, 
-			OPTIONAL_DECISION__PROP));
+			OPTIONAL_DECISION__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/references/data/impl/A_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/references/data/impl/A_Impl.java
@@ -415,8 +415,9 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		return A__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			NAME__PROP, 
 			CONTENTS__PROP, 
 			CHILDREN__PROP, 
@@ -425,11 +426,17 @@ public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 			OTHER__PROP, 
 			OTHERS__PROP, 
 			IN_OTHER__PROP, 
-			IN_OTHERS__PROP));
+			IN_OTHERS__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/references/data/impl/B_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/references/data/impl/B_Impl.java
@@ -163,15 +163,22 @@ public class B_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implemen
 		return B__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			NAME__PROP, 
 			IN_BS__PROP, 
-			IN_B__PROP));
+			IN_B__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/TestTransientProps.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/TestTransientProps.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: 2025 (c) Business Operation Systems GmbH <info@top-logic.com>
+ * 
+ * SPDX-License-Identifier: AGPL-3.0-only OR LicenseRef-BOS-TopLogic-1.0
+ */
+package test.transientprops;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import junit.framework.TestCase;
+import test.transientprops.data.A;
+import test.transientprops.data.B;
+import test.transientprops.data.C;
+
+/**
+ * Test case for transient properties.
+ */
+public class TestTransientProps extends TestCase {
+	
+	public void testA() {
+		assertEquals(set(A.X_2__PROP), A.create().transientProperties());
+		assertEquals(Arrays.asList(A.X_1__PROP, A.X_2__PROP), A.create().properties());
+	}
+
+	public void testB() {
+		assertEquals(set(A.X_2__PROP, B.Y_2__PROP), B.create().transientProperties());
+		assertEquals(Arrays.asList(A.X_1__PROP, A.X_2__PROP, B.Y_1__PROP, B.Y_2__PROP), B.create().properties());
+	}
+	
+	public void testC() {
+		assertEquals(set(A.X_2__PROP, B.Y_2__PROP, C.Z_2__PROP), C.create().transientProperties());
+		assertEquals(Arrays.asList(A.X_1__PROP, A.X_2__PROP, B.Y_1__PROP, B.Y_2__PROP, C.Z_1__PROP, C.Z_2__PROP), C.create().properties());
+	}
+	
+	private Set<String> set(String ...s) {
+		return new HashSet<>(Arrays.asList(s));
+	}
+
+}

--- a/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/A.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/A.java
@@ -1,0 +1,83 @@
+package test.transientprops.data;
+
+public interface A extends de.haumacher.msgbuf.data.DataObject, de.haumacher.msgbuf.binary.BinaryDataObject, de.haumacher.msgbuf.observer.Observable, de.haumacher.msgbuf.xml.XmlSerializable {
+
+	/** Type codes for the {@link test.transientprops.data.A} hierarchy. */
+	public enum TypeKind {
+
+		/** Type literal for {@link test.transientprops.data.A}. */
+		A,
+
+		/** Type literal for {@link test.transientprops.data.B}. */
+		B,
+
+		/** Type literal for {@link test.transientprops.data.C}. */
+		C,
+		;
+
+	}
+
+	/**
+	 * Creates a {@link test.transientprops.data.A} instance.
+	 */
+	static test.transientprops.data.A create() {
+		return new test.transientprops.data.impl.A_Impl();
+	}
+
+	/** Identifier for the {@link test.transientprops.data.A} type in JSON format. */
+	String A__TYPE = "A";
+
+	/** @see #getX1() */
+	String X_1__PROP = "x1";
+
+	/** @see #getX2() */
+	String X_2__PROP = "x2";
+
+	/** Identifier for the property {@link #getX1()} in binary format. */
+	static final int X_1__ID = 1;
+
+	/** The type code of this instance. */
+	TypeKind kind();
+
+	String getX1();
+
+	/**
+	 * @see #getX1()
+	 */
+	test.transientprops.data.A setX1(String value);
+
+	String getX2();
+
+	/**
+	 * @see #getX2()
+	 */
+	test.transientprops.data.A setX2(String value);
+
+	@Override
+	public test.transientprops.data.A registerListener(de.haumacher.msgbuf.observer.Listener l);
+
+	@Override
+	public test.transientprops.data.A unregisterListener(de.haumacher.msgbuf.observer.Listener l);
+
+	/** Reads a new instance from the given reader. */
+	static test.transientprops.data.A readA(de.haumacher.msgbuf.json.JsonReader in) throws java.io.IOException {
+		test.transientprops.data.impl.A_Impl result = new test.transientprops.data.impl.A_Impl();
+		result.readContent(in);
+		return result;
+	}
+
+	/** Reads a new instance from the given reader. */
+	static test.transientprops.data.A readA(de.haumacher.msgbuf.binary.DataReader in) throws java.io.IOException {
+		in.beginObject();
+		test.transientprops.data.A result = test.transientprops.data.impl.A_Impl.readA_Content(in);
+		in.endObject();
+		return result;
+	}
+
+	/** Creates a new {@link A} and reads properties from the content (attributes and inner tags) of the currently open element in the given {@link javax.xml.stream.XMLStreamReader}. */
+	public static A readA(javax.xml.stream.XMLStreamReader in) throws javax.xml.stream.XMLStreamException {
+		in.nextTag();
+		return test.transientprops.data.impl.A_Impl.readA_XmlContent(in);
+	}
+
+}

--- a/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/B.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/B.java
@@ -1,0 +1,65 @@
+package test.transientprops.data;
+
+public interface B extends A {
+
+	/**
+	 * Creates a {@link test.transientprops.data.B} instance.
+	 */
+	static test.transientprops.data.B create() {
+		return new test.transientprops.data.impl.B_Impl();
+	}
+
+	/** Identifier for the {@link test.transientprops.data.B} type in JSON format. */
+	String B__TYPE = "B";
+
+	/** @see #getY1() */
+	String Y_1__PROP = "y1";
+
+	/** @see #getY2() */
+	String Y_2__PROP = "y2";
+
+	/** Identifier for the property {@link #getY1()} in binary format. */
+	static final int Y_1__ID = 3;
+
+	String getY1();
+
+	/**
+	 * @see #getY1()
+	 */
+	test.transientprops.data.B setY1(String value);
+
+	String getY2();
+
+	/**
+	 * @see #getY2()
+	 */
+	test.transientprops.data.B setY2(String value);
+
+	@Override
+	test.transientprops.data.B setX1(String value);
+
+	@Override
+	test.transientprops.data.B setX2(String value);
+
+	/** Reads a new instance from the given reader. */
+	static test.transientprops.data.B readB(de.haumacher.msgbuf.json.JsonReader in) throws java.io.IOException {
+		test.transientprops.data.impl.B_Impl result = new test.transientprops.data.impl.B_Impl();
+		result.readContent(in);
+		return result;
+	}
+
+	/** Reads a new instance from the given reader. */
+	static test.transientprops.data.B readB(de.haumacher.msgbuf.binary.DataReader in) throws java.io.IOException {
+		in.beginObject();
+		test.transientprops.data.B result = test.transientprops.data.impl.B_Impl.readB_Content(in);
+		in.endObject();
+		return result;
+	}
+
+	/** Creates a new {@link B} and reads properties from the content (attributes and inner tags) of the currently open element in the given {@link javax.xml.stream.XMLStreamReader}. */
+	public static B readB(javax.xml.stream.XMLStreamReader in) throws javax.xml.stream.XMLStreamException {
+		in.nextTag();
+		return test.transientprops.data.impl.B_Impl.readB_XmlContent(in);
+	}
+
+}

--- a/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/C.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/C.java
@@ -1,0 +1,71 @@
+package test.transientprops.data;
+
+public interface C extends B {
+
+	/**
+	 * Creates a {@link test.transientprops.data.C} instance.
+	 */
+	static test.transientprops.data.C create() {
+		return new test.transientprops.data.impl.C_Impl();
+	}
+
+	/** Identifier for the {@link test.transientprops.data.C} type in JSON format. */
+	String C__TYPE = "C";
+
+	/** @see #getZ1() */
+	String Z_1__PROP = "z1";
+
+	/** @see #getZ2() */
+	String Z_2__PROP = "z2";
+
+	/** Identifier for the property {@link #getZ1()} in binary format. */
+	static final int Z_1__ID = 5;
+
+	String getZ1();
+
+	/**
+	 * @see #getZ1()
+	 */
+	test.transientprops.data.C setZ1(String value);
+
+	String getZ2();
+
+	/**
+	 * @see #getZ2()
+	 */
+	test.transientprops.data.C setZ2(String value);
+
+	@Override
+	test.transientprops.data.C setY1(String value);
+
+	@Override
+	test.transientprops.data.C setY2(String value);
+
+	@Override
+	test.transientprops.data.C setX1(String value);
+
+	@Override
+	test.transientprops.data.C setX2(String value);
+
+	/** Reads a new instance from the given reader. */
+	static test.transientprops.data.C readC(de.haumacher.msgbuf.json.JsonReader in) throws java.io.IOException {
+		test.transientprops.data.impl.C_Impl result = new test.transientprops.data.impl.C_Impl();
+		result.readContent(in);
+		return result;
+	}
+
+	/** Reads a new instance from the given reader. */
+	static test.transientprops.data.C readC(de.haumacher.msgbuf.binary.DataReader in) throws java.io.IOException {
+		in.beginObject();
+		test.transientprops.data.C result = test.transientprops.data.impl.C_Impl.readC_Content(in);
+		in.endObject();
+		return result;
+	}
+
+	/** Creates a new {@link C} and reads properties from the content (attributes and inner tags) of the currently open element in the given {@link javax.xml.stream.XMLStreamReader}. */
+	public static C readC(javax.xml.stream.XMLStreamReader in) throws javax.xml.stream.XMLStreamException {
+		in.nextTag();
+		return test.transientprops.data.impl.C_Impl.readC_XmlContent(in);
+	}
+
+}

--- a/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/impl/A_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/impl/A_Impl.java
@@ -1,63 +1,68 @@
-package test.novisit.impl;
+package test.transientprops.data.impl;
 
 /**
- * Implementation of {@link test.novisit.SimpleType}.
+ * Implementation of {@link test.transientprops.data.A}.
  */
-public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implements test.novisit.SimpleType {
+public class A_Impl extends de.haumacher.msgbuf.data.AbstractDataObject implements test.transientprops.data.A {
 
-	private String _str = "";
+	private String _x1 = "";
 
-	private int _x = 0;
+	private transient String _x2 = "";
 
 	/**
-	 * Creates a {@link SimpleType_Impl} instance.
+	 * Creates a {@link A_Impl} instance.
 	 *
-	 * @see test.novisit.SimpleType#create()
+	 * @see test.transientprops.data.A#create()
 	 */
-	public SimpleType_Impl() {
+	public A_Impl() {
 		super();
 	}
 
 	@Override
-	public final String getStr() {
-		return _str;
+	public TypeKind kind() {
+		return TypeKind.A;
 	}
 
 	@Override
-	public test.novisit.SimpleType setStr(String value) {
-		internalSetStr(value);
+	public final String getX1() {
+		return _x1;
+	}
+
+	@Override
+	public test.transientprops.data.A setX1(String value) {
+		internalSetX1(value);
 		return this;
 	}
 
-	/** Internal setter for {@link #getStr()} without chain call utility. */
-	protected final void internalSetStr(String value) {
-		_listener.beforeSet(this, STR__PROP, value);
-		_str = value;
-		_listener.afterChanged(this, STR__PROP);
+	/** Internal setter for {@link #getX1()} without chain call utility. */
+	protected final void internalSetX1(String value) {
+		_listener.beforeSet(this, X_1__PROP, value);
+		_x1 = value;
+		_listener.afterChanged(this, X_1__PROP);
 	}
 
 	@Override
-	public final int getX() {
-		return _x;
+	public final String getX2() {
+		return _x2;
 	}
 
 	@Override
-	public test.novisit.SimpleType setX(int value) {
-		internalSetX(value);
+	public test.transientprops.data.A setX2(String value) {
+		internalSetX2(value);
 		return this;
 	}
 
-	/** Internal setter for {@link #getX()} without chain call utility. */
-	protected final void internalSetX(int value) {
-		_listener.beforeSet(this, X__PROP, value);
-		_x = value;
-		_listener.afterChanged(this, X__PROP);
+	/** Internal setter for {@link #getX2()} without chain call utility. */
+	protected final void internalSetX2(String value) {
+		_listener.beforeSet(this, X_2__PROP, value);
+		_x2 = value;
+		_listener.afterChanged(this, X_2__PROP);
 	}
 
 	protected de.haumacher.msgbuf.observer.Listener _listener = de.haumacher.msgbuf.observer.Listener.NONE;
 
 	@Override
-	public test.novisit.SimpleType registerListener(de.haumacher.msgbuf.observer.Listener l) {
+	public test.transientprops.data.A registerListener(de.haumacher.msgbuf.observer.Listener l) {
 		internalRegisterListener(l);
 		return this;
 	}
@@ -67,7 +72,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	}
 
 	@Override
-	public test.novisit.SimpleType unregisterListener(de.haumacher.msgbuf.observer.Listener l) {
+	public test.transientprops.data.A unregisterListener(de.haumacher.msgbuf.observer.Listener l) {
 		internalUnregisterListener(l);
 		return this;
 	}
@@ -78,14 +83,14 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 
 	@Override
 	public String jsonType() {
-		return SIMPLE_TYPE__TYPE;
+		return A__TYPE;
 	}
 
 	static final java.util.List<String> PROPERTIES;
 	static {
 		java.util.List<String> local = java.util.Arrays.asList(
-			STR__PROP, 
-			X__PROP);
+			X_1__PROP, 
+			X_2__PROP);
 		PROPERTIES = java.util.Collections.unmodifiableList(local);
 	}
 
@@ -93,7 +98,7 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	static {
 		java.util.HashSet<String> tmp = new java.util.HashSet<>();
 		tmp.addAll(java.util.Arrays.asList(
-				));
+				X_2__PROP));
 		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
 	}
 
@@ -110,17 +115,17 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	@Override
 	public Object get(String field) {
 		switch (field) {
-			case STR__PROP: return getStr();
-			case X__PROP: return getX();
-			default: return test.novisit.SimpleType.super.get(field);
+			case X_1__PROP: return getX1();
+			case X_2__PROP: return getX2();
+			default: return test.transientprops.data.A.super.get(field);
 		}
 	}
 
 	@Override
 	public void set(String field, Object value) {
 		switch (field) {
-			case STR__PROP: internalSetStr((String) value); break;
-			case X__PROP: internalSetX((int) value); break;
+			case X_1__PROP: internalSetX1((String) value); break;
+			case X_2__PROP: internalSetX2((String) value); break;
 		}
 	}
 
@@ -132,17 +137,14 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	@Override
 	protected void writeFields(de.haumacher.msgbuf.json.JsonWriter out) throws java.io.IOException {
 		super.writeFields(out);
-		out.name(STR__PROP);
-		out.value(getStr());
-		out.name(X__PROP);
-		out.value(getX());
+		out.name(X_1__PROP);
+		out.value(getX1());
 	}
 
 	@Override
 	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
 		switch (field) {
-			case STR__PROP: setStr(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
-			case X__PROP: setX(in.nextInt()); break;
+			case X_1__PROP: setX1(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
 			default: super.readField(in, field);
 		}
 	}
@@ -162,15 +164,13 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	 * @throws java.io.IOException If writing fails.
 	 */
 	protected void writeFields(de.haumacher.msgbuf.binary.DataWriter out) throws java.io.IOException {
-		out.name(STR__ID);
-		out.value(getStr());
-		out.name(X__ID);
-		out.value(getX());
+		out.name(X_1__ID);
+		out.value(getX1());
 	}
 
-	/** Helper for creating an object of type {@link test.novisit.SimpleType} from a polymorphic composition. */
-	public static test.novisit.SimpleType readSimpleType_Content(de.haumacher.msgbuf.binary.DataReader in) throws java.io.IOException {
-		test.novisit.impl.SimpleType_Impl result = new SimpleType_Impl();
+	/** Helper for creating an object of type {@link test.transientprops.data.A} from a polymorphic composition. */
+	public static test.transientprops.data.A readA_Content(de.haumacher.msgbuf.binary.DataReader in) throws java.io.IOException {
+		test.transientprops.data.impl.A_Impl result = new A_Impl();
 		result.readContent(in);
 		return result;
 	}
@@ -186,24 +186,23 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	/** Consumes the value for the field with the given ID and assigns its value. */
 	protected void readField(de.haumacher.msgbuf.binary.DataReader in, int field) throws java.io.IOException {
 		switch (field) {
-			case STR__ID: setStr(in.nextString()); break;
-			case X__ID: setX(in.nextInt()); break;
+			case X_1__ID: setX1(in.nextString()); break;
 			default: in.skipValue(); 
 		}
 	}
 
-	/** XML element name representing a {@link test.novisit.SimpleType} type. */
-	public static final String SIMPLE_TYPE__XML_ELEMENT = "simple-type";
+	/** XML element name representing a {@link test.transientprops.data.A} type. */
+	public static final String A__XML_ELEMENT = "a";
 
-	/** XML attribute or element name of a {@link #getStr} property. */
-	private static final String STR__XML_ATTR = "str";
+	/** XML attribute or element name of a {@link #getX1} property. */
+	private static final String X_1__XML_ATTR = "x-1";
 
-	/** XML attribute or element name of a {@link #getX} property. */
-	private static final String X__XML_ATTR = "x";
+	/** XML attribute or element name of a {@link #getX2} property. */
+	private static final String X_2__XML_ATTR = "x-2";
 
 	@Override
 	public String getXmlTagName() {
-		return SIMPLE_TYPE__XML_ELEMENT;
+		return A__XML_ELEMENT;
 	}
 
 	@Override
@@ -214,8 +213,8 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 
 	/** Serializes all fields that are written as XML attributes. */
 	protected void writeAttributes(javax.xml.stream.XMLStreamWriter out) throws javax.xml.stream.XMLStreamException {
-		out.writeAttribute(STR__XML_ATTR, getStr());
-		out.writeAttribute(X__XML_ATTR, Integer.toString(getX()));
+		out.writeAttribute(X_1__XML_ATTR, getX1());
+		out.writeAttribute(X_2__XML_ATTR, getX2());
 	}
 
 	/** Serializes all fields that are written as XML elements. */
@@ -223,9 +222,9 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 		// No element fields.
 	}
 
-	/** Creates a new {@link test.novisit.SimpleType} and reads properties from the content (attributes and inner tags) of the currently open element in the given {@link javax.xml.stream.XMLStreamReader}. */
-	public static SimpleType_Impl readSimpleType_XmlContent(javax.xml.stream.XMLStreamReader in) throws javax.xml.stream.XMLStreamException {
-		SimpleType_Impl result = new SimpleType_Impl();
+	/** Creates a new {@link test.transientprops.data.A} and reads properties from the content (attributes and inner tags) of the currently open element in the given {@link javax.xml.stream.XMLStreamReader}. */
+	public static A_Impl readA_XmlContent(javax.xml.stream.XMLStreamReader in) throws javax.xml.stream.XMLStreamException {
+		A_Impl result = new A_Impl();
 		result.readContentXml(in);
 		return result;
 	}
@@ -253,12 +252,12 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	/** Parses the given attribute value and assigns it to the field with the given name. */
 	protected void readFieldXmlAttribute(String name, String value) {
 		switch (name) {
-			case STR__XML_ATTR: {
-				setStr(value);
+			case X_1__XML_ATTR: {
+				setX1(value);
 				break;
 			}
-			case X__XML_ATTR: {
-				setX(Integer.parseInt(value));
+			case X_2__XML_ATTR: {
+				setX2(value);
 				break;
 			}
 			default: {
@@ -270,12 +269,12 @@ public class SimpleType_Impl extends de.haumacher.msgbuf.data.AbstractDataObject
 	/** Reads the element under the cursor and assigns its contents to the field with the given name. */
 	protected void readFieldXmlElement(javax.xml.stream.XMLStreamReader in, String localName) throws javax.xml.stream.XMLStreamException {
 		switch (localName) {
-			case STR__XML_ATTR: {
-				setStr(in.getElementText());
+			case X_1__XML_ATTR: {
+				setX1(in.getElementText());
 				break;
 			}
-			case X__XML_ATTR: {
-				setX(Integer.parseInt(in.getElementText()));
+			case X_2__XML_ATTR: {
+				setX2(in.getElementText());
 				break;
 			}
 			default: {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/impl/B_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/impl/B_Impl.java
@@ -1,0 +1,236 @@
+package test.transientprops.data.impl;
+
+/**
+ * Implementation of {@link test.transientprops.data.B}.
+ */
+public class B_Impl extends test.transientprops.data.impl.A_Impl implements test.transientprops.data.B {
+
+	private String _y1 = "";
+
+	private transient String _y2 = "";
+
+	/**
+	 * Creates a {@link B_Impl} instance.
+	 *
+	 * @see test.transientprops.data.B#create()
+	 */
+	public B_Impl() {
+		super();
+	}
+
+	@Override
+	public TypeKind kind() {
+		return TypeKind.B;
+	}
+
+	@Override
+	public final String getY1() {
+		return _y1;
+	}
+
+	@Override
+	public test.transientprops.data.B setY1(String value) {
+		internalSetY1(value);
+		return this;
+	}
+
+	/** Internal setter for {@link #getY1()} without chain call utility. */
+	protected final void internalSetY1(String value) {
+		_listener.beforeSet(this, Y_1__PROP, value);
+		_y1 = value;
+		_listener.afterChanged(this, Y_1__PROP);
+	}
+
+	@Override
+	public final String getY2() {
+		return _y2;
+	}
+
+	@Override
+	public test.transientprops.data.B setY2(String value) {
+		internalSetY2(value);
+		return this;
+	}
+
+	/** Internal setter for {@link #getY2()} without chain call utility. */
+	protected final void internalSetY2(String value) {
+		_listener.beforeSet(this, Y_2__PROP, value);
+		_y2 = value;
+		_listener.afterChanged(this, Y_2__PROP);
+	}
+
+	@Override
+	public test.transientprops.data.B setX1(String value) {
+		internalSetX1(value);
+		return this;
+	}
+
+	@Override
+	public test.transientprops.data.B setX2(String value) {
+		internalSetX2(value);
+		return this;
+	}
+
+	@Override
+	public String jsonType() {
+		return B__TYPE;
+	}
+
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			Y_1__PROP, 
+			Y_2__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.transientprops.data.impl.A_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
+
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.transientprops.data.impl.A_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				Y_2__PROP));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
+
+	@Override
+	public java.util.List<String> properties() {
+		return PROPERTIES;
+	}
+
+	@Override
+	public java.util.Set<String> transientProperties() {
+		return TRANSIENT_PROPERTIES;
+	}
+
+	@Override
+	public Object get(String field) {
+		switch (field) {
+			case Y_1__PROP: return getY1();
+			case Y_2__PROP: return getY2();
+			default: return super.get(field);
+		}
+	}
+
+	@Override
+	public void set(String field, Object value) {
+		switch (field) {
+			case Y_1__PROP: internalSetY1((String) value); break;
+			case Y_2__PROP: internalSetY2((String) value); break;
+			default: super.set(field, value); break;
+		}
+	}
+
+	@Override
+	protected void writeFields(de.haumacher.msgbuf.json.JsonWriter out) throws java.io.IOException {
+		super.writeFields(out);
+		out.name(Y_1__PROP);
+		out.value(getY1());
+	}
+
+	@Override
+	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
+		switch (field) {
+			case Y_1__PROP: setY1(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
+			default: super.readField(in, field);
+		}
+	}
+
+	@Override
+	protected void writeFields(de.haumacher.msgbuf.binary.DataWriter out) throws java.io.IOException {
+		super.writeFields(out);
+		out.name(Y_1__ID);
+		out.value(getY1());
+	}
+
+	/** Helper for creating an object of type {@link test.transientprops.data.B} from a polymorphic composition. */
+	public static test.transientprops.data.B readB_Content(de.haumacher.msgbuf.binary.DataReader in) throws java.io.IOException {
+		test.transientprops.data.impl.B_Impl result = new B_Impl();
+		result.readContent(in);
+		return result;
+	}
+
+	@Override
+	protected void readField(de.haumacher.msgbuf.binary.DataReader in, int field) throws java.io.IOException {
+		switch (field) {
+			case Y_1__ID: setY1(in.nextString()); break;
+			default: super.readField(in, field);
+		}
+	}
+
+	/** XML element name representing a {@link test.transientprops.data.B} type. */
+	public static final String B__XML_ELEMENT = "b";
+
+	/** XML attribute or element name of a {@link #getY1} property. */
+	private static final String Y_1__XML_ATTR = "y-1";
+
+	/** XML attribute or element name of a {@link #getY2} property. */
+	private static final String Y_2__XML_ATTR = "y-2";
+
+	@Override
+	public String getXmlTagName() {
+		return B__XML_ELEMENT;
+	}
+
+	/** Serializes all fields that are written as XML attributes. */
+	@Override
+	protected void writeAttributes(javax.xml.stream.XMLStreamWriter out) throws javax.xml.stream.XMLStreamException {
+		super.writeAttributes(out);
+		out.writeAttribute(Y_1__XML_ATTR, getY1());
+		out.writeAttribute(Y_2__XML_ATTR, getY2());
+	}
+
+	/** Serializes all fields that are written as XML elements. */
+	@Override
+	protected void writeElements(javax.xml.stream.XMLStreamWriter out) throws javax.xml.stream.XMLStreamException {
+		super.writeElements(out);
+		// No element fields.
+	}
+
+	/** Creates a new {@link test.transientprops.data.B} and reads properties from the content (attributes and inner tags) of the currently open element in the given {@link javax.xml.stream.XMLStreamReader}. */
+	public static B_Impl readB_XmlContent(javax.xml.stream.XMLStreamReader in) throws javax.xml.stream.XMLStreamException {
+		B_Impl result = new B_Impl();
+		result.readContentXml(in);
+		return result;
+	}
+
+	@Override
+	protected void readFieldXmlAttribute(String name, String value) {
+		switch (name) {
+			case Y_1__XML_ATTR: {
+				setY1(value);
+				break;
+			}
+			case Y_2__XML_ATTR: {
+				setY2(value);
+				break;
+			}
+			default: {
+				super.readFieldXmlAttribute(name, value);
+			}
+		}
+	}
+
+	@Override
+	protected void readFieldXmlElement(javax.xml.stream.XMLStreamReader in, String localName) throws javax.xml.stream.XMLStreamException {
+		switch (localName) {
+			case Y_1__XML_ATTR: {
+				setY1(in.getElementText());
+				break;
+			}
+			case Y_2__XML_ATTR: {
+				setY2(in.getElementText());
+				break;
+			}
+			default: {
+				super.readFieldXmlElement(in, localName);
+			}
+		}
+	}
+
+}

--- a/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/impl/C_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/impl/C_Impl.java
@@ -1,0 +1,248 @@
+package test.transientprops.data.impl;
+
+/**
+ * Implementation of {@link test.transientprops.data.C}.
+ */
+public class C_Impl extends test.transientprops.data.impl.B_Impl implements test.transientprops.data.C {
+
+	private String _z1 = "";
+
+	private transient String _z2 = "";
+
+	/**
+	 * Creates a {@link C_Impl} instance.
+	 *
+	 * @see test.transientprops.data.C#create()
+	 */
+	public C_Impl() {
+		super();
+	}
+
+	@Override
+	public TypeKind kind() {
+		return TypeKind.C;
+	}
+
+	@Override
+	public final String getZ1() {
+		return _z1;
+	}
+
+	@Override
+	public test.transientprops.data.C setZ1(String value) {
+		internalSetZ1(value);
+		return this;
+	}
+
+	/** Internal setter for {@link #getZ1()} without chain call utility. */
+	protected final void internalSetZ1(String value) {
+		_listener.beforeSet(this, Z_1__PROP, value);
+		_z1 = value;
+		_listener.afterChanged(this, Z_1__PROP);
+	}
+
+	@Override
+	public final String getZ2() {
+		return _z2;
+	}
+
+	@Override
+	public test.transientprops.data.C setZ2(String value) {
+		internalSetZ2(value);
+		return this;
+	}
+
+	/** Internal setter for {@link #getZ2()} without chain call utility. */
+	protected final void internalSetZ2(String value) {
+		_listener.beforeSet(this, Z_2__PROP, value);
+		_z2 = value;
+		_listener.afterChanged(this, Z_2__PROP);
+	}
+
+	@Override
+	public test.transientprops.data.C setY1(String value) {
+		internalSetY1(value);
+		return this;
+	}
+
+	@Override
+	public test.transientprops.data.C setY2(String value) {
+		internalSetY2(value);
+		return this;
+	}
+
+	@Override
+	public test.transientprops.data.C setX1(String value) {
+		internalSetX1(value);
+		return this;
+	}
+
+	@Override
+	public test.transientprops.data.C setX2(String value) {
+		internalSetX2(value);
+		return this;
+	}
+
+	@Override
+	public String jsonType() {
+		return C__TYPE;
+	}
+
+	@SuppressWarnings("hiding")
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			Z_1__PROP, 
+			Z_2__PROP);
+		java.util.List<String> tmp = new java.util.ArrayList<>();
+		tmp.addAll(test.transientprops.data.impl.B_Impl.PROPERTIES);
+		tmp.addAll(local);
+		PROPERTIES = java.util.Collections.unmodifiableList(tmp);
+	}
+
+	@SuppressWarnings("hiding")
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(test.transientprops.data.impl.B_Impl.TRANSIENT_PROPERTIES);
+		tmp.addAll(java.util.Arrays.asList(
+				Z_2__PROP));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
+
+	@Override
+	public java.util.List<String> properties() {
+		return PROPERTIES;
+	}
+
+	@Override
+	public java.util.Set<String> transientProperties() {
+		return TRANSIENT_PROPERTIES;
+	}
+
+	@Override
+	public Object get(String field) {
+		switch (field) {
+			case Z_1__PROP: return getZ1();
+			case Z_2__PROP: return getZ2();
+			default: return super.get(field);
+		}
+	}
+
+	@Override
+	public void set(String field, Object value) {
+		switch (field) {
+			case Z_1__PROP: internalSetZ1((String) value); break;
+			case Z_2__PROP: internalSetZ2((String) value); break;
+			default: super.set(field, value); break;
+		}
+	}
+
+	@Override
+	protected void writeFields(de.haumacher.msgbuf.json.JsonWriter out) throws java.io.IOException {
+		super.writeFields(out);
+		out.name(Z_1__PROP);
+		out.value(getZ1());
+	}
+
+	@Override
+	protected void readField(de.haumacher.msgbuf.json.JsonReader in, String field) throws java.io.IOException {
+		switch (field) {
+			case Z_1__PROP: setZ1(de.haumacher.msgbuf.json.JsonUtil.nextStringOptional(in)); break;
+			default: super.readField(in, field);
+		}
+	}
+
+	@Override
+	protected void writeFields(de.haumacher.msgbuf.binary.DataWriter out) throws java.io.IOException {
+		super.writeFields(out);
+		out.name(Z_1__ID);
+		out.value(getZ1());
+	}
+
+	/** Helper for creating an object of type {@link test.transientprops.data.C} from a polymorphic composition. */
+	public static test.transientprops.data.C readC_Content(de.haumacher.msgbuf.binary.DataReader in) throws java.io.IOException {
+		test.transientprops.data.impl.C_Impl result = new C_Impl();
+		result.readContent(in);
+		return result;
+	}
+
+	@Override
+	protected void readField(de.haumacher.msgbuf.binary.DataReader in, int field) throws java.io.IOException {
+		switch (field) {
+			case Z_1__ID: setZ1(in.nextString()); break;
+			default: super.readField(in, field);
+		}
+	}
+
+	/** XML element name representing a {@link test.transientprops.data.C} type. */
+	public static final String C__XML_ELEMENT = "c";
+
+	/** XML attribute or element name of a {@link #getZ1} property. */
+	private static final String Z_1__XML_ATTR = "z-1";
+
+	/** XML attribute or element name of a {@link #getZ2} property. */
+	private static final String Z_2__XML_ATTR = "z-2";
+
+	@Override
+	public String getXmlTagName() {
+		return C__XML_ELEMENT;
+	}
+
+	/** Serializes all fields that are written as XML attributes. */
+	@Override
+	protected void writeAttributes(javax.xml.stream.XMLStreamWriter out) throws javax.xml.stream.XMLStreamException {
+		super.writeAttributes(out);
+		out.writeAttribute(Z_1__XML_ATTR, getZ1());
+		out.writeAttribute(Z_2__XML_ATTR, getZ2());
+	}
+
+	/** Serializes all fields that are written as XML elements. */
+	@Override
+	protected void writeElements(javax.xml.stream.XMLStreamWriter out) throws javax.xml.stream.XMLStreamException {
+		super.writeElements(out);
+		// No element fields.
+	}
+
+	/** Creates a new {@link test.transientprops.data.C} and reads properties from the content (attributes and inner tags) of the currently open element in the given {@link javax.xml.stream.XMLStreamReader}. */
+	public static C_Impl readC_XmlContent(javax.xml.stream.XMLStreamReader in) throws javax.xml.stream.XMLStreamException {
+		C_Impl result = new C_Impl();
+		result.readContentXml(in);
+		return result;
+	}
+
+	@Override
+	protected void readFieldXmlAttribute(String name, String value) {
+		switch (name) {
+			case Z_1__XML_ATTR: {
+				setZ1(value);
+				break;
+			}
+			case Z_2__XML_ATTR: {
+				setZ2(value);
+				break;
+			}
+			default: {
+				super.readFieldXmlAttribute(name, value);
+			}
+		}
+	}
+
+	@Override
+	protected void readFieldXmlElement(javax.xml.stream.XMLStreamReader in, String localName) throws javax.xml.stream.XMLStreamException {
+		switch (localName) {
+			case Z_1__XML_ATTR: {
+				setZ1(in.getElementText());
+				break;
+			}
+			case Z_2__XML_ATTR: {
+				setZ2(in.getElementText());
+				break;
+			}
+			default: {
+				super.readFieldXmlElement(in, localName);
+			}
+		}
+	}
+
+}

--- a/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/transientprops.proto
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/transientprops/data/transientprops.proto
@@ -1,0 +1,16 @@
+package test.transientprops.data;
+
+message A {
+	string x1;
+	transient string x2;
+}
+
+message B extends A {
+	string y1;
+	transient string y2;
+}
+
+message C extends B {
+	string z1;
+	transient string z2;
+}

--- a/de.haumacher.msgbuf.generator/src/test/java/test/types/data/impl/SearchRequest_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/types/data/impl/SearchRequest_Impl.java
@@ -101,15 +101,22 @@ public class SearchRequest_Impl extends de.haumacher.msgbuf.data.AbstractDataObj
 		return SEARCH_REQUEST__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
 			QUERY__PROP, 
 			PAGE_NUMBER__PROP, 
-			RESULT_PER_PAGE__PROP));
+			RESULT_PER_PAGE__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/underscorename/impl/AnnotatedMessage_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/underscorename/impl/AnnotatedMessage_Impl.java
@@ -44,13 +44,20 @@ public class AnnotatedMessage_Impl extends test.underscorename.impl.BaseMsg_Impl
 		return ANNOTATED_MESSAGE__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			ANNOTATED_FIELD__PROP));
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			ANNOTATED_FIELD__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/de.haumacher.msgbuf.generator/src/test/java/test/underscorename/impl/SomeName_Impl.java
+++ b/de.haumacher.msgbuf.generator/src/test/java/test/underscorename/impl/SomeName_Impl.java
@@ -44,13 +44,20 @@ public class SomeName_Impl extends test.underscorename.impl.BaseMsg_Impl impleme
 		return SOME_NAME__TYPE;
 	}
 
-	private static java.util.List<String> PROPERTIES = java.util.Collections.unmodifiableList(
-		java.util.Arrays.asList(
-			MY_FIELD__PROP));
+	static final java.util.List<String> PROPERTIES;
+	static {
+		java.util.List<String> local = java.util.Arrays.asList(
+			MY_FIELD__PROP);
+		PROPERTIES = java.util.Collections.unmodifiableList(local);
+	}
 
-	private static java.util.Set<String> TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(new java.util.HashSet<>(
-			java.util.Arrays.asList(
-				)));
+	static final java.util.Set<String> TRANSIENT_PROPERTIES;
+	static {
+		java.util.HashSet<String> tmp = new java.util.HashSet<>();
+		tmp.addAll(java.util.Arrays.asList(
+				));
+		TRANSIENT_PROPERTIES = java.util.Collections.unmodifiableSet(tmp);
+	}
 
 	@Override
 	public java.util.List<String> properties() {

--- a/msgbuf-parent/pom.xml
+++ b/msgbuf-parent/pom.xml
@@ -124,7 +124,7 @@
 				<artifactId>maven-gpg-plugin</artifactId>
 				<version>1.5</version>
 				<configuration>
-					<keyname>3FDEA7509C2E6ACFBAAE4E4C062F98BC833AC2BF</keyname>
+					<keyname>${gpg.keyname}</keyname>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
The reflection methods properties() and transientProperties() must also report inherited properties.